### PR TITLE
Runner: fix solver's random seed

### DIFF
--- a/runner/run_solver.py
+++ b/runner/run_solver.py
@@ -14,7 +14,7 @@ def get_solver(solver_name):
         raise ValueError(f"Solver '{solver_name}' is not recognized")
 
     solver_class = getattr(linopy.solvers, solver_enum.name)
-    return solver_class()
+    return solver_class(random_seed = 0)
 
 
 def main(solver_name, input_file):

--- a/runner/run_solver.py
+++ b/runner/run_solver.py
@@ -14,7 +14,20 @@ def get_solver(solver_name):
         raise ValueError(f"Solver '{solver_name}' is not recognized")
 
     solver_class = getattr(linopy.solvers, solver_enum.name)
-    return solver_class(random_seed = 0)
+
+    seed_options = {
+        "highs": {"random_seed": 0},
+        "glpk": {"seed": 0},
+        "gurobi": {"seed": 0},
+        "scip": {
+            "randomization/randomseedshift": 0,
+        },
+    }
+
+    if solver_name.lower() in seed_options:
+        return solver_class(**seed_options[solver_name.lower()])
+    else:
+        return solver_class()
 
 
 def main(solver_name, input_file):


### PR DESCRIPTION
### Summary

### 1. HIGHS

**Add a random seed to the HiGHS solver**

lp file: https://drive.usercontent.google.com/download?id=1SrFi3qDK6JpUM-pzyyz11c8PzFq74XEO&export=download&authuser=0

Note: Download and store _problem_5.lp_ to _runner/benchmarks_


Command

`python runner/run_solver.py highs  runner/benchmarks/problem_5.lp
`
- with random_seed = 0

```
Running HiGHS 1.7.2 (git hash: 184e327): Copyright (c) 2024 HiGHS under MIT licence terms
Coefficient ranges:
  Matrix [1e-04, 2e+02]
  Cost   [1e-02, 4e+05]
  Bound  [0e+00, 0e+00]
  RHS    [3e+04, 8e+04]
Presolving model
74734 rows, 57219 cols, 197922 nonzeros  0s
74734 rows, 57219 cols, 197922 nonzeros  0s
Presolve : Reductions: rows 74734(-65435); columns 57219(-4106); elements 197922(-104577)
Solving the presolved LP
Using EKK dual simplex solver - serial
  Iteration        Objective     Infeasibilities num(sum)
          0     0.0000000000e+00 Pr: 8760(2.77547e+09) 0s
      47775     3.1642198959e+10 Pr: 7314(1.01773e+10); Du: 0(4.23833e-07) 6s
      49337     3.1714138112e+10 Pr: 0(0) 6s
      49337     3.1714138112e+10 Pr: 0(0) 6s
Solving the original LP from the solution after postsolve
Model   status      : Optimal
Simplex   iterations: 49337
Objective value     :  3.1714138112e+10
HiGHS run time      :          6.51
```

- with random_seed = 1

```
Coefficient ranges:
  Matrix [1e-04, 2e+02]
  Cost   [1e-02, 4e+05]
  Bound  [0e+00, 0e+00]
  RHS    [3e+04, 8e+04]
Presolving model
74734 rows, 57219 cols, 197922 nonzeros  0s
74734 rows, 57219 cols, 197922 nonzeros  0s
Presolve : Reductions: rows 74734(-65435); columns 57219(-4106); elements 197922(-104577)
Solving the presolved LP
Using EKK dual simplex solver - serial
  Iteration        Objective     Infeasibilities num(sum)
          0     0.0000000000e+00 Pr: 8760(2.77547e+09) 0s
      48111     3.1224216219e+10 Pr: 14601(3.77124e+10); Du: 0(9.91213e-07) 5s
      56311     3.1714138112e+10 Pr: 0(0) 9s
Solving the original LP from the solution after postsolve
Model   status      : Optimal
Simplex   iterations: 56311
Objective value     :  3.1714138112e+10
HiGHS run time      :          9.05
```

- compare result
![image](https://github.com/user-attachments/assets/3f89ad50-bb09-41ea-944d-ec98c1b7aa93)


- run again with random_seed = 0

```
Running HiGHS 1.7.2 (git hash: 184e327): Copyright (c) 2024 HiGHS under MIT licence terms
Coefficient ranges:
  Matrix [1e-04, 2e+02]
  Cost   [1e-02, 4e+05]
  Bound  [0e+00, 0e+00]
  RHS    [3e+04, 8e+04]
Presolving model
74734 rows, 57219 cols, 197922 nonzeros  0s
74734 rows, 57219 cols, 197922 nonzeros  0s
Presolve : Reductions: rows 74734(-65435); columns 57219(-4106); elements 197922(-104577)
Solving the presolved LP
Using EKK dual simplex solver - serial
  Iteration        Objective     Infeasibilities num(sum)
          0     0.0000000000e+00 Pr: 8760(2.77547e+09) 0s
      47775     3.1642198959e+10 Pr: 7314(1.01773e+10); Du: 0(4.23833e-07) 5s
      49337     3.1714138112e+10 Pr: 0(0) 6s
      49337     3.1714138112e+10 Pr: 0(0) 6s
Solving the original LP from the solution after postsolve
Model   status      : Optimal
Simplex   iterations: 49337
Objective value     :  3.1714138112e+10
HiGHS run time      :          6.39
```

- It's the same as the first run
![image](https://github.com/user-attachments/assets/49fb33f2-e1c5-47de-af6b-a03384348c7c)


### 2. GUROBI

Passing seed as parameter for gurobi
ref: https://docs.gurobi.com/projects/optimizer/en/current/reference/parameters/descriptions.html#seed
Since Gurobi only supports simple problems in the free version, I will use a sample .lp file

_simple.lp_

command to run 

`python runner/run_solver.py gurobi runner/benchmarks/simple.lp 
`

```
Minimize
  obj: 12 x1 + 15 x2 + 25 x3 + 18 x4 + 20 x5 + 30 x6 + 22 x7 + 28 x8 + 19 x9 + 23 x10

Subject To
  c1: 2 x1 + 3 x2 + 5 x3 + 7 x4 + 8 x5 + 6 x6 + 3 x7 + 5 x8 + 6 x9 + 3 x10 >= 80
  c2: 5 x1 + 2 x2 + 6 x3 + 4 x4 + 3 x5 + 7 x6 + 2 x7 + 3 x8 + 4 x9 + 7 x10 <= 120
  c3: 4 x1 + 6 x2 + 7 x3 + 5 x4 + 8 x5 + 3 x6 + 4 x7 + 6 x8 + 5 x9 + 7 x10 >= 90
  c4: 6 x1 + 4 x2 + 5 x3 + 3 x4 + 2 x5 + 7 x6 + 6 x7 + 5 x8 + 4 x9 + 3 x10 <= 130
  c5: 8 x1 + 5 x2 + 4 x3 + 7 x4 + 3 x5 + 6 x6 + 5 x7 + 6 x8 + 4 x9 + 5 x10 >= 100
  c6: 3 x1 + 5 x2 + 6 x3 + 7 x4 + 8 x5 + 3 x6 + 2 x7 + 4 x8 + 7 x9 + 6 x10 <= 110
  c7: 7 x1 + 6 x2 + 3 x3 + 4 x4 + 5 x5 + 6 x6 + 8 x7 + 5 x8 + 3 x9 + 2 x10 >= 75

Bounds
  0 <= x1 <= 10
  0 <= x2 <= 8
  0 <= x3 <= 12
  0 <= x4 <= 9
  0 <= x5 <= 15
  0 <= x6 <= 6
  0 <= x7 <= 11
  0 <= x8 <= 7
  0 <= x9 <= 10
  0 <= x10 <= 8

Binary
  x2 x4 x6 x8 x10

End

```

- if seed == 0

log

```
Reading time = 0.00 seconds
obj: 7 rows, 10 columns, 70 nonzeros
Gurobi Optimizer version 11.0.3 build v11.0.3rc0 (linux64 - "Ubuntu 22.04.3 LTS")

CPU model: Intel(R) Core(TM) i5-7500T CPU @ 2.70GHz, instruction set [SSE2|AVX|AVX2]
Thread count: 4 physical cores, 4 logical processors, using up to 4 threads

Optimize a model with 7 rows, 10 columns and 70 nonzeros
Model fingerprint: 0x0ab105ac
Variable types: 5 continuous, 5 integer (5 binary)
Coefficient statistics:
  Matrix range     [2e+00, 8e+00]
  Objective range  [1e+01, 3e+01]
  Bounds range     [1e+00, 2e+01]
  RHS range        [8e+01, 1e+02]
Found heuristic solution: objective 456.6000000
Presolve time: 0.01s
Presolved: 7 rows, 10 columns, 70 nonzeros
Variable types: 5 continuous, 5 integer (5 binary)
Found heuristic solution: objective 422.1000000

Root relaxation: objective 2.638621e+02, 3 iterations, 0.00 seconds (0.00 work units)

    Nodes    |    Current Node    |     Objective Bounds      |     Work
 Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time

*    0     0               0     263.8620690  263.86207  0.00%     -    0s

Explored 1 nodes (3 simplex iterations) in 0.03 seconds (0.00 work units)
Thread count was 4 (of 4 available processors)

Solution count 3: 263.862 422.1 456.6 

Optimal solution found (tolerance 1.00e-04)
Best objective 2.638620689655e+02, best bound 2.638620689655e+02, gap 0.0000%
Dual values of MILP couldn't be parsed
Status: ok
Termination condition: optimal
Solution: 10 primals, 0 duals
Objective: 2.64e+02
Solver model: available
Solver message: 2
{"runtime": 0.06505203247070312, "status": "ok", "condition": "optimal", "objective": 263.86206896551727}
```



- if seed == 1

it will show **Set parameter Seed to value 1**


log

```
Reading time = 0.00 seconds
obj: 7 rows, 10 columns, 70 nonzeros
Set parameter Seed to value 1
Gurobi Optimizer version 11.0.3 build v11.0.3rc0 (linux64 - "Ubuntu 22.04.3 LTS")

CPU model: Intel(R) Core(TM) i5-7500T CPU @ 2.70GHz, instruction set [SSE2|AVX|AVX2]
Thread count: 4 physical cores, 4 logical processors, using up to 4 threads

Optimize a model with 7 rows, 10 columns and 70 nonzeros
Model fingerprint: 0x0ab105ac
Variable types: 5 continuous, 5 integer (5 binary)
Coefficient statistics:
  Matrix range     [2e+00, 8e+00]
  Objective range  [1e+01, 3e+01]
  Bounds range     [1e+00, 2e+01]
  RHS range        [8e+01, 1e+02]
Found heuristic solution: objective 456.6000000
Presolve time: 0.00s
Presolved: 7 rows, 10 columns, 70 nonzeros
Variable types: 5 continuous, 5 integer (5 binary)
Found heuristic solution: objective 422.1000000

Root relaxation: objective 2.638621e+02, 3 iterations, 0.00 seconds (0.00 work units)

    Nodes    |    Current Node    |     Objective Bounds      |     Work
 Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time

*    0     0               0     263.8620690  263.86207  0.00%     -    0s

Explored 1 nodes (3 simplex iterations) in 0.00 seconds (0.00 work units)
Thread count was 4 (of 4 available processors)

Solution count 3: 263.862 422.1 456.6 

Optimal solution found (tolerance 1.00e-04)
Best objective 2.638620689655e+02, best bound 2.638620689655e+02, gap 0.0000%
Dual values of MILP couldn't be parsed
{"runtime": 0.0063629150390625, "status": "ok", "condition": "optimal", "objective": 263.86206896551727}
```


### 3. GLPK
When using command
`glpsol --help
`


```
General options:
  ...
   --seed value      initialize pseudo-random number generator used in
                     MathProg model with specified seed (any integer);
                     if seed value is ?, some random seed will be used
  ...
```

In custom linopy

_linopy/solvers.py_

```
class GLPK(Solver):
    """
    Solver subclass for the GLPK solver.

    Attributes
    ----------
    **solver_options    options for the given solver
    """
    ...
    if self.solver_options:
            command += (
                " ".join(
                    "--" + " ".join([k, str(v)]) for k, v in self.solver_options.items()
                )
                + " "
            )
     command = command.strip()
    ...
```

We can use the seed as a solver option, just like we did with Gurobi.

I tested this with the following command:

python runner/run_solver.py glpk runner/benchmarks/simple.lp 

with the following seed values:
 
```
speed: 100
speed: 0
speed: '?'
```
It worked, and the log showed:

`{"runtime": 0.010498046875, "status": "ok", "condition": "optimal", "objective": 257.1538462}
`
However, when I used:

`random_seed: 100
`

the result was:
`{"runtime": 0.0020487308502197266, "status": "warning", "condition": "unknown", "objective": NaN}
`

The reason different seed values like speed: 100, speed: 0, and speed: '?' produce the same result is that the GLPK solver follows a fixed set of rules without randomness. Since the algorithm is deterministic, it will always find the same optimal solution regardless of the seed.

### 4. SCIP


**Add a random seed to the SCIP solver**
```
"scip": {
            "randomization/randomseedshift": 0,
            },
```

lp file: https://drive.usercontent.google.com/download?id=1SrFi3qDK6JpUM-pzyyz11c8PzFq74XEO&export=download&authuser=0

Note: Download and store problem_5.lp to runner/benchmarks

Command
```
python runner/run_solver.py scip runner/benchmarks/problem_5.lp 
```

with random_seed = 0

```
original problem has 61325 variables (0 bin, 0 int, 0 impl, 61325 cont) and 140169 constraints
presolving:
   (0.3s) symmetry computation started: requiring (bin +, int +, cont +), (fixed: bin -, int -, cont -)
   (0.5s) no symmetry present (symcode time: 0.06)
presolving (0 rounds: 0 fast, 0 medium, 0 exhaustive):
 0 deleted vars, 0 deleted constraints, 0 added constraints, 0 tightened bounds, 0 added holes, 0 changed sides, 0 changed coefficients
 0 implications, 0 cliques
presolved problem has 61325 variables (0 bin, 0 int, 0 impl, 61325 cont) and 140169 constraints
 140169 constraints of type <linear>
Presolving Time: 0.28

 time | node  | left  |LP iter|LP it/n|mem/heur|mdpt |vars |cons |rows |cuts |sepa|confs|strbr|  dualbound   | primalbound  |  gap   | compl. 
* 107s|     1 |     0 | 64205 |     - |    LP  |   0 |  61k|  74k|  74k|   0 |  0 |   0 |   0 | 3.171414e+10 | 3.171414e+10 |   0.00%| unknown
  107s|     1 |     0 | 64205 |     - |   458M |   0 |  61k|  74k|  74k|   0 |  0 |   0 |   0 | 3.171414e+10 | 3.171414e+10 |   0.00%| unknown

SCIP Status        : problem is solved [optimal solution found]
Solving Time (sec) : 106.96
Solving Nodes      : 1
Primal Bound       : +3.17141381118609e+10 (1 solutions)
Dual Bound         : +3.17141381118609e+10
Gap                : 0.00 %
{"runtime": 108.03856945037842, "status": "ok", "condition": "optimal", "objective": 31714138111.860943}
```

with random_seed = 1

```
original problem has 61325 variables (0 bin, 0 int, 0 impl, 61325 cont) and 140169 constraints
presolving:
   (0.3s) symmetry computation started: requiring (bin +, int +, cont +), (fixed: bin -, int -, cont -)
   (0.5s) no symmetry present (symcode time: 0.06)
presolving (0 rounds: 0 fast, 0 medium, 0 exhaustive):
 0 deleted vars, 0 deleted constraints, 0 added constraints, 0 tightened bounds, 0 added holes, 0 changed sides, 0 changed coefficients
 0 implications, 0 cliques
presolved problem has 61325 variables (0 bin, 0 int, 0 impl, 61325 cont) and 140169 constraints
 140169 constraints of type <linear>
Presolving Time: 0.28

 time | node  | left  |LP iter|LP it/n|mem/heur|mdpt |vars |cons |rows |cuts |sepa|confs|strbr|  dualbound   | primalbound  |  gap   | compl. 
* 112s|     1 |     0 | 68116 |     - |    LP  |   0 |  61k|  74k|  74k|   0 |  0 |   0 |   0 | 3.171414e+10 | 3.171414e+10 |   0.00%| unknown
  112s|     1 |     0 | 68116 |     - |   458M |   0 |  61k|  74k|  74k|   0 |  0 |   0 |   0 | 3.171414e+10 | 3.171414e+10 |   0.00%| unknown

SCIP Status        : problem is solved [optimal solution found]
Solving Time (sec) : 111.63
Solving Nodes      : 1
Primal Bound       : +3.17141381118609e+10 (1 solutions)
Dual Bound         : +3.17141381118609e+10
Gap                : 0.00 %
{"runtime": 112.69987440109253, "status": "ok", "condition": "optimal", "objective": 31714138111.860943}
```

- compare result
![image](https://github.com/user-attachments/assets/f3e3a298-ac9c-4999-aa63-126d1d66afb6)


again with random_seed = 0

```
original problem has 61325 variables (0 bin, 0 int, 0 impl, 61325 cont) and 140169 constraints
presolving:
   (0.3s) symmetry computation started: requiring (bin +, int +, cont +), (fixed: bin -, int -, cont -)
   (0.5s) no symmetry present (symcode time: 0.07)
presolving (0 rounds: 0 fast, 0 medium, 0 exhaustive):
 0 deleted vars, 0 deleted constraints, 0 added constraints, 0 tightened bounds, 0 added holes, 0 changed sides, 0 changed coefficients
 0 implications, 0 cliques
presolved problem has 61325 variables (0 bin, 0 int, 0 impl, 61325 cont) and 140169 constraints
 140169 constraints of type <linear>
Presolving Time: 0.29

 time | node  | left  |LP iter|LP it/n|mem/heur|mdpt |vars |cons |rows |cuts |sepa|confs|strbr|  dualbound   | primalbound  |  gap   | compl. 
* 107s|     1 |     0 | 64205 |     - |    LP  |   0 |  61k|  74k|  74k|   0 |  0 |   0 |   0 | 3.171414e+10 | 3.171414e+10 |   0.00%| unknown
  107s|     1 |     0 | 64205 |     - |   458M |   0 |  61k|  74k|  74k|   0 |  0 |   0 |   0 | 3.171414e+10 | 3.171414e+10 |   0.00%| unknown

SCIP Status        : problem is solved [optimal solution found]
Solving Time (sec) : 107.50
Solving Nodes      : 1
Primal Bound       : +3.17141381118609e+10 (1 solutions)
Dual Bound         : +3.17141381118609e+10
Gap                : 0.00 %
{"runtime": 108.5811915397644, "status": "ok", "condition": "optimal", "objective": 31714138111.860943}
```
It's the same as the first run
![image](https://github.com/user-attachments/assets/6ae05635-7401-47f0-8334-aa6a960b5c92)



