### PR TITLE
[fix] Improved test data matches metadata and some housekeeping

### DIFF
--- a/results/benchmark_results.csv
+++ b/results/benchmark_results.csv
@@ -1,4 +1,4 @@
-Benchmark,Solver,Status,Termination Condition,Objective Value,Runtime (s),Memory Usage (MB)
+Benchmark,Solver,Status,Termination Condition,Objective Value,Runtime (s),Memory Usage (MB),Max Integrality Violation,Duality Gap
 pypsa-eur-sec-2-24h,highs,ok,optimal,15337522234.402815,52.85370707511902,431.176,,
 pypsa-eur-sec-2-24h,glpk,TO,Timeout,,900,193.164,,
 pypsa-eur-sec-2-24h,scip,ok,optimal,15337522234.40238,284.5882496833801,761.444,,

--- a/website/app.py
+++ b/website/app.py
@@ -1,4 +1,10 @@
+from pathlib import Path
+
+import pandas as pd
 import streamlit as st
+
+# local
+from utils.file_utils import load_metadata
 
 st.markdown(
     """
@@ -40,6 +46,27 @@ pages = [
     st.Page("history.py", title="Solver Performance History"),
     st.Page("raw-results.py", title="Full Results"),
 ]
+
+metadata = load_metadata("benchmarks/pypsa/metadata.yaml")
+
+# Convert metadata to a DataFrame for easier filtering
+metadata_df = pd.DataFrame(metadata).T.reset_index()
+metadata_df.rename(columns={"index": "Benchmark Name"}, inplace=True)
+# Load the data from the CSV file
+data_url = Path(__file__).parent.parent / "results/benchmark_results.csv"
+raw_df = pd.read_csv(data_url)
+df = raw_df
+
+
+# Assert that the set of benchmark names in the metadata matches those in the data
+csv_benchmarks = set(raw_df["Benchmark"].unique())
+metadata_benchmarks = set(metadata_df["Benchmark Name"].unique())
+# Assertion to check if both sets are the same
+assert csv_benchmarks == metadata_benchmarks, (
+    f"Mismatch between CSV benchmarks and metadata benchmarks:\n"
+    f"In CSV but not metadata: {csv_benchmarks - metadata_benchmarks}\n"
+    f"In metadata but not CSV: {metadata_benchmarks - csv_benchmarks}"
+)
 
 pg = st.navigation(pages)
 pg.run()

--- a/website/app.py
+++ b/website/app.py
@@ -54,12 +54,11 @@ metadata_df = pd.DataFrame(metadata).T.reset_index()
 metadata_df.rename(columns={"index": "Benchmark Name"}, inplace=True)
 # Load the data from the CSV file
 data_url = Path(__file__).parent.parent / "results/benchmark_results.csv"
-raw_df = pd.read_csv(data_url)
-df = raw_df
+data_df = pd.read_csv(data_url)
 
 
 # Assert that the set of benchmark names in the metadata matches those in the data
-csv_benchmarks = set(raw_df["Benchmark"].unique())
+csv_benchmarks = set(data_df["Benchmark"].unique())
 metadata_benchmarks = set(metadata_df["Benchmark Name"].unique())
 # Assertion to check if both sets are the same
 assert csv_benchmarks == metadata_benchmarks, (

--- a/website/benchmarks.py
+++ b/website/benchmarks.py
@@ -3,16 +3,11 @@ from pathlib import Path
 import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
-import yaml
 from st_aggrid import AgGrid
 from st_aggrid.grid_options_builder import GridOptionsBuilder
 
-
-# Load the metadata from the YAML file
-def load_metadata(yaml_file):
-    with open(yaml_file, "r") as file:
-        return yaml.safe_load(file)
-
+# local
+from utils.file_utils import load_metadata
 
 # Load the data from the CSV files
 data_url_mean_stddev = (

--- a/website/compare.py
+++ b/website/compare.py
@@ -53,16 +53,11 @@ solver1 = st.selectbox(
     index=solver_list.tolist().index(default_solver1),
 )
 
-# Dropdown to select Solver 2 only if there’s more than one solver
-if default_solver2:
-    solver2 = st.selectbox(
-        "Select Solver 2",
-        solver_list,
-        index=solver_list.tolist().index(default_solver2),
-    )
-else:
-    st.write("Only one solver available. Please add more solvers to compare.")
-    st.stop()
+solver2 = st.selectbox(
+    "Select Solver 2",
+    solver_list,
+    index=solver_list.tolist().index(default_solver2),
+)
 
 if ui.button(
     text="Compare Solvers",

--- a/website/compare.py
+++ b/website/compare.py
@@ -3,18 +3,11 @@ from pathlib import Path
 import pandas as pd
 import streamlit as st
 import streamlit_shadcn_ui as ui
-import yaml
 
 # local
 from components.compare_chart import create_comparison_chart
 from components.filter import generate_filtered_metadata
-
-
-# Load benchmark metadata
-def load_metadata(file_path):
-    with open(file_path, "r") as file:
-        return yaml.safe_load(file)
-
+from utils.file_utils import load_metadata
 
 metadata = load_metadata("benchmarks/pypsa/metadata.yaml")
 
@@ -41,23 +34,36 @@ if "Solver Version" in df.columns:
 
 st.title("Compare Solvers")
 
-# Set default solvers
-default_solver1 = "gurobi"
-default_solver2 = "highs"
+# Get list of unique solvers from the data
+solver_list = df["Solver"].unique()
+# Set default solvers based on available solver list length
+if len(solver_list) > 1:
+    default_solver1 = solver_list[0]
+    default_solver2 = solver_list[1]
+elif len(solver_list) == 1:
+    default_solver1 = solver_list[0]
+    default_solver2 = None
+else:
+    st.write("No solvers available for comparison.")
+    st.stop()
 
-# Dropdown to select Solver 1 with default value Gurobi
+# Dropdown to select Solver 1 with default value
 solver1 = st.selectbox(
     "Select Solver 1",
-    df["Solver"].unique(),
-    index=df["Solver"].unique().tolist().index(default_solver1),
+    solver_list,
+    index=solver_list.tolist().index(default_solver1),
 )
 
-# Dropdown to select Solver 2 with default value Highs
-solver2 = st.selectbox(
-    "Select Solver 2",
-    df["Solver"].unique(),
-    index=df["Solver"].unique().tolist().index(default_solver2),
-)
+# Dropdown to select Solver 2 only if there’s more than one solver
+if default_solver2:
+    solver2 = st.selectbox(
+        "Select Solver 2",
+        solver_list,
+        index=solver_list.tolist().index(default_solver2),
+    )
+else:
+    st.write("Only one solver available. Please add more solvers to compare.")
+    st.stop()
 
 if ui.button(
     text="Compare Solvers",

--- a/website/compare.py
+++ b/website/compare.py
@@ -40,11 +40,10 @@ solver_list = df["Solver"].unique()
 if len(solver_list) > 1:
     default_solver1 = solver_list[0]
     default_solver2 = solver_list[1]
-elif len(solver_list) == 1:
-    default_solver1 = solver_list[0]
-    default_solver2 = None
 else:
-    st.write("No solvers available for comparison.")
+    st.write(
+        "Fewer than 2 solvers available for comparison. Please add more solvers to compare."
+    )
     st.stop()
 
 # Dropdown to select Solver 1 with default value

--- a/website/history.py
+++ b/website/history.py
@@ -3,16 +3,10 @@ from pathlib import Path
 import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
-import yaml
 
 # local
 from components.filter import generate_filtered_metadata
-
-
-def load_metadata(file_path):
-    with open(file_path, "r") as file:
-        return yaml.safe_load(file)
-
+from utils.file_utils import load_metadata
 
 metadata = load_metadata("benchmarks/pypsa/metadata.yaml")
 

--- a/website/home.py
+++ b/website/home.py
@@ -1,20 +1,12 @@
-# main script
 from pathlib import Path
 
 import pandas as pd
 import streamlit as st
-import yaml
 from components.filter import generate_filtered_metadata
 
 # local
 from components.home_chart import render_benchmark_scatter_plot
-
-
-# Load benchmark metadata
-def load_metadata(file_path):
-    with open(file_path, "r") as file:
-        return yaml.safe_load(file)
-
+from utils.file_utils import load_metadata
 
 metadata = load_metadata("benchmarks/pypsa/metadata.yaml")
 

--- a/website/raw-results.py
+++ b/website/raw-results.py
@@ -2,18 +2,11 @@ from pathlib import Path
 
 import pandas as pd
 import streamlit as st
-import yaml
 
 # local
 from components.benchmark_table import display_table
 from components.filter import generate_filtered_metadata
-
-
-# Load benchmark metadata
-def load_metadata(file_path):
-    with open(file_path, "r") as file:
-        return yaml.safe_load(file)
-
+from utils.file_utils import load_metadata
 
 metadata = load_metadata("benchmarks/pypsa/metadata.yaml")
 

--- a/website/utils/file_utils.py
+++ b/website/utils/file_utils.py
@@ -1,0 +1,7 @@
+import yaml
+
+
+# Load benchmark metadata
+def load_metadata(file_path):
+    with open(file_path, "r") as file:
+        return yaml.safe_load(file)


### PR DESCRIPTION
- Moved the assertion to check that the set of benchmark names in the metadata matches those in the data from home.py to app.py.
- Added a load\_metadata function for reusability and better code organization.
- Updated the Compare page to handle cases where the number of solvers is 1 or 0.