### PR TITLE
Metadata for GenX, PowerModels and Tulipa benchmarks from the JuMP-Highs platform

### DIFF
--- a/benchmarks/jump_highs_platform/Metadata_genx.yaml
+++ b/benchmarks/jump_highs_platform/Metadata_genx.yaml
@@ -1,0 +1,140 @@
+## Metadata for samples from https://github.com/jump-dev/open-energy-modeling-benchmarks/tree/main/GenX/cases
+1_three_zones (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/GenX_1_three_zones-2b66b543f23170441438f4d10acfb436136aef55ebcc483d502c5493a62d163c.mps.gz):
+  Short description: Three Zones, a one-year example with hourly resolution, contains zones representing Massachusetts, Connecticut, and Maine. The ten represented resources include natural gas, solar PV, wind, and lithium-ion battery storage.
+  Model name: GenX
+  Version:
+  Technique: MILP
+  Kind of problem: Infrastructure
+  Sectors: Power
+  Time horizon: Single period (1 year)
+  Temporal resolution: Hourly
+  Spatial resolution: 3 nodes (Massachussetts, Connecticut, Maine)
+  MILP features: Unit commitment
+  N. of constraints: 171878
+  N. of variables: 171880 (continuous), 16635 (integer), 3696 (binary)
+
+2_three_zones_w_electrolyzer (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/GenX_2_three_zones_w_electrolyzer-f211ccdcc1a2145c1f4854dcc714f50d5b8fcc524bac465a2022ffb8942ffd53.mps.gz):
+  Short description: This is a one-year example with hourly resolution which contains three zones representing Massachusetts, Connecticut, and Maine. It is designed to show the electrolyzer feature in GenX. The sixteen represented resources include natural gas, solar PV, wind, electrolyzer and lithium-ion battery storage.
+  Model name: GenX
+  Version:
+  Technique: MILP
+  Kind of problem: Infrastructure
+  Sectors: Power
+  Time horizon: Single period (1 year)
+  Temporal resolution: Hourly
+  Spatial resolution: 3 nodes (Massachussetts, Connecticut, Maine)
+  MILP features: Unit commitment
+  N. of constraints: 232867
+  N. of variables: 232869 (continuous), 16635 (integer), 3696 (binary)
+
+3_three_zones_w_co2_capture (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/GenX_3_three_zones_w_co2_capture-3222908514bd19ae55895811eb847ad882270e280657123420407a885ccb34bc.mps.gz):
+  Short description: This is a one-year example with hourly resolution which contains zones representing Massachusetts, Connecticut, and Maine. The ten represented resources include natural gas, solar PV, wind, and lithium-ion battery storage and biomass with carbon capture and storage. This examples shows the usage of CO2, biomass, and piecewise fuel usage related functions of GenX.
+  Model name: GenX
+  Version:
+  Technique: MILP
+  Kind of problem: Infrastructure
+  Sectors: Power
+  Time horizon: Single period (1 year)
+  Temporal resolution: Hourly
+  Spatial resolution: 3 nodes (Massachussetts, Connecticut, Maine)
+  MILP features: Unit commitment
+  N. of constraints: 171878
+  N. of variables: 171880 (continuous), 16635 (integer), 3696 (binary)
+
+4_three_zones_w_policies_slack (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/GenX_4_three_zones_w_policies_slack-0be00acbe74d795dfc6aec53239998a93ac0310563b3e65fca00f2acebe2b6c1.mps.gz):
+  Short description: This is a one-year example with hourly resolution which contains zones representing Massachusetts, Connecticut, and Maine. It is designed to show how to use slack variables to meet a policy constraint if it cannot be met cost-effectively by normal means. The ten represented resources include natural gas, solar PV, wind, and lithium-ion battery storage. It additionally contains example input files (inside the policies folder) establishing slack variables for policy constraints (e.g. the Capacity Reserve Margin, CO2 Cap, etc.). These slack variables allow the relevant constraints to be violated at the cost of a specified objective function penalty, which can be used to either identify problematic constraints without causing infeasibilities in GenX, or to set price caps beyond which policies are no longer enforced. These slack variables will only be created if the relevant input data (Capacity_reserve_margin_slack.csv, CO2_cap_slack.csv, Energy_share_requirement_slack.csv, or the PriceCap column in Minimum_capacity_requirement.csv and Maximum_capacity_requirement.csv) are present. If any of these inputs are not present, GenX will instantiate the relevant policy as a hard constraint, which will throw an infeasibility error if violated.
+  Model name: GenX
+  Version:
+  Technique: MILP
+  Kind of problem: Infrastructure
+  Sectors: Power
+  Time horizon: Single period (1 year)
+  Temporal resolution: Hourly
+  Spatial resolution: 3 nodes (Massachussetts, Connecticut, Maine)
+  MILP features: Unit commitment
+  N. of constraints: 184817
+  N. of variables: 184819 (continuous), 16635 (integer), 3696 (binary)
+
+5_three_zones_w_piecewise_fuel (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/GenX_5_three_zones_w_piecewise_fuel-51ff0e52d559b549f9e45a13eb267156a2416566f126d1567e1846353a4e9936.mps.gz):
+  Short description: This is a one-year example with hourly resolution which contains zones representing Massachusetts, Connecticut, and Maine. The ten represented resources include natural gas, solar PV, wind, and lithium-ion battery storage and biomass with carbon capture and storage. For natural gas ccs generator, we provide picewise fuel usage (PWFU) parameters to represent the fuel consumption at differernt load point. Please refer to the documentation for more details on PWFU parameters and corresponding data requirements. When settings["UCommit"] >= 1 and PWFU parameters are provided in Thermal.csv, the standard heat rate (i.e., Heat_Rate_MMBTU_per_MWh) will not be used. Instead, the heat rate will be calculated based on the PWFU parameters.
+  Model name: GenX
+  Version:
+  Technique: MILP
+  Kind of problem: Infrastructure
+  Sectors: Power
+  Time horizon: Single period (1 year)
+  Temporal resolution: Hourly
+  Spatial resolution: 3 nodes (Massachussetts, Connecticut, Maine)
+  MILP features: Unit commitment and picewise fuel usage
+  N. of constraints: 205142
+  N. of variables: 205144 (continuous), 16635 (integer), 3696 (binary)
+
+6_three_zones_w_multistage (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/GenX_6_three_zones_w_multistage-62d4538e93e8e775de4f754baf121d4996da332da11066a1a496e298f2319641.mps.gz):
+  Short description: This is a toy multi-stage example with hourly resolution which contains zones representing Massachusetts, Connecticut, and Maine. It is designed to show how to run multi-stage investment planning models. The ten represented resources include natural gas, solar PV, wind, and lithium-ion battery storage.
+  Model name: GenX
+  Version:
+  Technique: MILP
+  Kind of problem: Infrastructure
+  Sectors: Power
+  Time horizon: Multi-period (3 years)
+  Temporal resolution: Hourly
+  Spatial resolution: 3 nodes (Massachussetts, Connecticut, Maine)
+  MILP features: Unit commitment
+  N. of constraints: 171944
+  N. of variables: 171946 (continuous), 16638 (integer), 3696 (binary)
+
+7_three_zones_w_colocated_VRE_storage (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/GenX_7_three_zones_w_colocated_VRE_storage-053eaf1f441d6cb6da75f0dfdaab95f8011afb3be0a34e3b0ae02dbd1043ee74.mps.gz):
+  Short description: This example system shows the functionalities of the colocated VRE+storage module of GenX. It runs a three-zone, 24-hour continental US model, with a carbon constraint and with a long duration energy storage resource that the model can choose to co-locate with either solar or wind. In this case, the storage resource is forced in via minimum and maximum capacity requirement constraints, but these constraints could be easily removed (although the storage resource has a cost of zero in this case so a cost would have to be added).
+  Model name: GenX
+  Version:
+  Technique: MILP
+  Kind of problem: Infrastructure
+  Sectors: Power
+  Time horizon: Single period (1 year)
+  Temporal resolution: 24 hourly
+  Spatial resolution: 3 nodes (Massachussetts, Connecticut, Maine)
+  MILP features: None (unit commitment is linearized)
+  N. of constraints: 4325
+  N. of variables: 4327 (continuous), 219 (integer), 48 (binary)
+
+8_three_zones_w_colocated_VRE_storage_electrolyzers (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/GenX_8_three_zones_w_colocated_VRE_storage_electrolyzers-5a9e9622b0df9ff8e06923ccddd72047e156022ae36bd98981ac89bfb0f83790.mps.gz):
+  Short description: This example system shows the functionalities of the colocated VRE+storage+Electrolyzer module of GenX. It runs a three-zone, 1,680-hour continental US model, with a carbon constraint and with a long duration energy storage resource that the model can choose to co-locate with either solar or wind. In this case, the storage resource is forced in via minimum and maximum capacity requirement constraints, but these constraints could be easily removed (although the storage resource has a cost of zero in this case so a cost would have to be added).
+  Model name: GenX
+  Version:
+  Technique: MILP
+  Kind of problem: Infrastructure
+  Sectors: Power
+  Time horizon: Single period (1 year)
+  Temporal resolution: Hourly
+  Spatial resolution: 3 nodes (Massachussetts, Connecticut, Maine)
+  MILP features: None (unit commitment is linearized)
+  N. of constraints: 302449
+  N. of variables: 302451 (continuous), 15123 (integer), 3360 (binary)
+
+9_three_zones_w_retrofit (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/GenX_9_three_zones_w_retrofit-8a89ca27ab8836ba9d561011fa6f8daa1481d8ff6509e371ce48f1357a3fdf47.mps.gz):
+  Short description: This is a one-year example with hourly resolution which contains zones representing Massachusetts, Connecticut, and Maine. The twenty-two represented resources include natural gas, solar PV, wind, lithium-ion battery, and coal power plants. This examples shows the usage of the retrofit module of GenX, and the model will be allowed to retire as well as retrofit the existing coal power plants and replacing the coal with blue ammonia with 85% efficiency. 
+  Model name: GenX
+  Version:
+  Technique: MILP
+  Kind of problem: Infrastructure
+  Sectors: Power
+  Time horizon: Single period (1 year)
+  Temporal resolution: Hourly
+  Spatial resolution: 3 nodes (Massachussetts, Connecticut, Maine)
+  MILP features: None (unit commitment is linearized)
+  N. of constraints: 438008
+  N. of variables: 438010 (continuous), 83181 (integer), 3696 (binary)
+
+10_IEEE_9_bus_DC_OPF (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/GenX_10_IEEE_9_bus_DC_OPF-79dee0225f3120ff0403a4b59238ede01562914e4dbf068d832e5d960e3afc40.mps.gz):
+  Short description: This examples shows the usage of DC_OPF related functions of GenX. The IEEE 9-bus system is a standard test case for power system optimization problems. In this example, there are three thermal generators and three loads.
+  Model name: GenX
+  Version:
+  Technique: MILP
+  Kind of problem: DC optimal power flow
+  Sectors: Power
+  Time horizon: Single period (1 year)
+  Temporal resolution: Hourly
+  Spatial resolution: 9 nodes
+  MILP features: Unit commitment
+  N. of constraints: 1235166
+  N. of variables: 1235168 (continuous), 78843 (integer), 0 (binary)

--- a/benchmarks/jump_highs_platform/Metadata_powermodels.yaml
+++ b/benchmarks/jump_highs_platform/Metadata_powermodels.yaml
@@ -1,0 +1,72 @@
+## Metadata for samples from https://github.com/jump-dev/open-energy-modeling-benchmarks/tree/main/PowerModels
+pglib_opf_case162_ieee_dtc (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/PowerModelsOTS_pglib_opf_case162_ieee_dtc.m-e44d1cc9578fe03e1568c393ab3924265857b7a2383e6384df4df1a820185c73.mps.gz):
+  Short description: System stability study based on the IEEE 17-Generator Dynamic Test Case with 162 buses and 17 generators
+  Model name: PowerModels
+  Version:
+  Technique: MILP
+  Kind of problem: Steady-state optimal power flow
+  Sectors: Power
+  Time horizon: N/A
+  Temporal resolution: N/A
+  Spatial resolution: 162 nodes
+  MILP features: 
+  N. of constraints: 1867
+  N. of variables: 1869 (continuous), 0 (integer), 284 (binary)
+
+pglib_opf_case1803_snem (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/PowerModelsOTS_pglib_opf_case1803_snem.m-43f8f35813a79b40f197737028098bf5eac73ef2776f3aa2687576ad1d439541.mps.gz):
+  Short description: Optimal Power Flow data for the Synthetic National Electricity Market (SNEM) Australia - Mainland subnetwork
+  Model name: PowerModels
+  Version:
+  Technique: LP  
+  Kind of problem: Steady-state optimal power flow
+  Sectors: Power
+  Time horizon: N/A
+  Temporal resolution: N/A
+  Spatial resolution: 1803 nodes
+  MILP features:
+  N. of constraints: 18574
+  N. of variables: 18576 (continuous), 0 (integer), 2795 (binary)
+
+pglib_opf_case1951_rte (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/PowerModelsOTS_pglib_opf_case1951_rte.m-96db1a2bb31ca33d4fe3ccb1fa30358f157cd3493cff87ae8f16fa8a6a3b1e48.mps.gz):
+  Short description: 
+  Model name: PowerModels
+  Version:
+  Technique: MILP  
+  Kind of problem: Steady-state optimal power flow
+  Sectors: Power
+  Time horizon: N/A
+  Temporal resolution: N/A
+  Spatial resolution: 1951 nodes
+  MILP features:
+  N. of constraints: 17528
+  N. of variables: 17530 (continuous), 0 (integer), 2596 (binary)
+
+pglib_opf_case2848 (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/PowerModelsOTS_pglib_opf_case2848_rte.m-8546f681e53f8663080268242343f948670d9ddcd40ed4b2da6ab94ec1e0fc05.mps.gz):
+  Short description: 
+  Model name: PowerModels
+  Version:
+  Technique: MILP  
+  Kind of problem: Steady-state optimal power flow
+  Sectors: Power
+  Time horizon: N/A
+  Temporal resolution: N/A
+  Spatial resolution: 2848 nodes
+  MILP features: 
+  N. of constraints: 25505
+  N. of variables: 25507 (continuous), 0 (integer), 3776 (binary)
+
+pglib_opf_case2868 (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/PowerModelsOTS_pglib_opf_case2868_rte.m-bf313f2631231ef9a5301580b317b461c49901a503fd898ee35cf791f1d8bea6.mps.gz):
+  Short description:
+  Model name: PowerModels
+  Version:
+  Technique: MILP  
+  Kind of problem: Steady-state optimal power flow
+  Sectors: Power
+  Time horizon: N/A
+  Temporal resolution: N/A
+  Spatial resolution: 2868 nodes
+  MILP features: 
+  N. of constraints: 25717
+  N. of variables: 25719 (continuous), 0 (integer), 3808 (binary)
+
+

--- a/benchmarks/jump_highs_platform/Metadata_tulipa.yaml
+++ b/benchmarks/jump_highs_platform/Metadata_tulipa.yaml
@@ -1,0 +1,42 @@
+## Metadata for samples from https://github.com/jump-dev/open-energy-modeling-benchmarks/tree/main/TulipaEnergyModel
+1_EU_investment_simple:
+  Short description: European-level investment and operation model to consider integer investments and unit commitment variables
+  Model name: Tulipa
+  Version:
+  Technique: MILP
+  Kind of problem: Infrastructure
+  Sectors: Power
+  Time horizon: Single period (1 year)
+  MILP features: Unit commitment
+
+Sizes:
+1_EU_investment_simple-24h (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/TulipaEnergyModel_1_EU_investment_simple_24h-dc195d31e02ab753b5f047a4e754d2d387b59e15ac813c515b7fab21651779ea.mps.gz):
+- Temporal resolution: 24 hours
+  Spatial resolution: 28 nodes
+  N. of constraints: 4746
+  N. of variables: 6658 (continuous), 251 (integer), 7 (binary)
+1_EU_investment_simple-168h (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/TulipaEnergyModel_1_EU_investment_simple_168h-a213cb9c037b9b9e0d0d38a1b7644a46407203a1f8e5f036c9e39870270c4a4f.mps.gz):
+- Temporal resolution: 168 hours
+  Spatial resolution: 28 nodes
+  N. of constraints: 46592
+  N. of variables: 46594 (continuous), 251 (integer), 7 (binary)
+1_EU_investment_simple_672h (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/TulipaEnergyModel_1_EU_investment_simple_672h-336e9a77dd9deae1ef81069c4e3f0c4c39cbbe0bc24b4d4e3f666657cbc76ab6.mps.gz):
+- Temporal resolution: 672 hours
+  Spatial resolution: 28 nodes
+  N. of constraints: 186368
+  N. of variables: 186370 (continuous), 251 (integer), 7 (binary)
+1_EU_investment_simple-2016h (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/TulipaEnergyModel_1_EU_investment_simple_2016h-6f7e83e8d3d3d676153925691417a73265d784e70f52b3f70eaa9664921dcd85.mps.gz):
+- Temporal resolution: 2016 hours
+  Spatial resolution: 28 nodes
+  N. of constraints: 559104
+  N. of variables: 559106 (continuous), 251 (integer), 7 (binary)
+1_EU_investment_simple_4032h (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/TulipaEnergyModel_1_EU_investment_simple_4032h-76d00dd60487dc27e60808bb6421b3091a937cfa503e37de4ef6927757f8ec11.mps.gz):
+- Temporal resolution: 4032 hours
+  Spatial resolution: 28 nodes
+  N. of constraints: 1118208
+  N. of variables: 1118210 (continuous), 251 (integer), 7 (binary)
+1_EU_investment_simple_8760h (https://github.com/jump-dev/open-energy-modeling-benchmarks/blob/main/instances/TulipaEnergyModel_1_EU_investment_simple_8760h-beb8fc0072ed50c7bf40d264ffb87ba24de4ae6736d55a7c0a78209f2c5883ef.mps.gz):
+- Temporal resolution: 8760 hours
+  Spatial resolution: 28 nodes
+  N. of constraints: 2429440
+  N. of variables: 2429442 (continuous), 251 (integer), 7 (binary)


### PR DESCRIPTION
Hi @siddharth-krishna , I added the metadata for all the GenX, PowerModels and Tulipa benchmarks on the JuMP-Highs platform. Some notes:
- The Sienna ones are still missing (I hope to be able to work on them on Monday)
- For the first time I added continuous variables as size parameters (I was thinking to do so for PyPSA benchmarks, too)
- Tulipa benchmarks are also classified by size as in the current version of PyPSA metadata
- We could work on increasing the number of GenX-based benchmarks removing unit commitment from at least some of the benchmarks on the platform (as they're all MILP at the current status)