### PR TITLE
Website: show total number of (filtered) benchmarks

### DIFF
--- a/website/components/filter.py
+++ b/website/components/filter.py
@@ -74,10 +74,14 @@ def display_filter_status(df, metadata_df):
     total_benchmarks = len(metadata_df["Benchmark Name"].unique())
     active_benchmarks = len(df["Benchmark"].unique())
 
+    filters_active = total_benchmarks != active_benchmarks
+
     with st.sidebar:
-        if total_benchmarks != active_benchmarks:
+        if filters_active:
             st.write(
                 f"### Filters are active; showing {active_benchmarks}/{total_benchmarks} benchmarks."
             )
         else:
             st.write("### Showing all benchmarks")
+
+    return filters_active

--- a/website/home.py
+++ b/website/home.py
@@ -89,7 +89,7 @@ if not filtered_metadata.empty:
     df = filter_data(df, filtered_metadata)
 
 # Filter status
-display_filter_status(df, filtered_metadata)
+filters_active = display_filter_status(df, filtered_metadata)
 
 
 def combine_sgm_tables(df):
@@ -119,11 +119,7 @@ def combine_sgm_tables(df):
         # Exclude TO values for max_runtime based on runtime and status
         runtime_status = group[["Runtime (s)", "Status"]]
         valid_runtimes = runtime_status[runtime_status["Status"] == "ok"]["Runtime (s)"]
-        max_runtime = (
-            (valid_runtimes.max())
-            if not valid_runtimes.empty
-            else "No valid max runtime"
-        )
+        max_runtime = (valid_runtimes.max()) if not valid_runtimes.empty else "N/A"
 
         # Calculate the number of benchmarks solved
         solved_benchmarks = len(group[group["Status"] == "ok"])
@@ -191,13 +187,15 @@ def combine_sgm_tables(df):
 if not df.empty:
     # Generate the Combined Table
     sgm_combined_df = combine_sgm_tables(df)
-
     sizes_count = len(df[["Benchmark", "Size"]].drop_duplicates())
     # Display the Combined Table
-    st.subheader("Results:")
+    st.subheader("Results")
+
+    filter_label = "**filtered**" if filters_active else ""
     st.write(
-        f"Solved benchmarks is the number of benchmarks where the solver returns an ok status, out of {sizes_count} **filtered** benchmarks"
+        f"Solved benchmarks is the number of benchmarks where the solver returns an ok status, out of {sizes_count} {filter_label} benchmarks"
     )
+
     st.table(sgm_combined_df)
 
 # Render scatter plot

--- a/website/home.py
+++ b/website/home.py
@@ -113,6 +113,10 @@ def combine_sgm_tables(df):
         runtime_values = group["Runtime (s)"]
         sgm_runtime = calculate_sgm(runtime_values)
 
+        # Calculate Min and Max Runtime
+        min_runtime = str(round(runtime_values.min(), 1))
+        max_runtime = str(round(runtime_values.max(), 1))
+
         # Calculate the number of benchmarks solved
         solved_benchmarks = len(group[group["Status"] == "ok"])
 
@@ -120,6 +124,8 @@ def combine_sgm_tables(df):
             {
                 "Solver": solver,
                 "Version": version,
+                "Min Runtime": min_runtime,
+                "Max Runtime": max_runtime,
                 "SGM Runtime": sgm_runtime,
                 "Solved Benchmarks": solved_benchmarks,
             }
@@ -157,7 +163,15 @@ def combine_sgm_tables(df):
 
     # Drop raw SGM values
     combined_df = combined_df[
-        ["Solver", "Version", "SGM Runtime", "SGM Memory", "Solved Benchmarks"]
+        [
+            "Solver",
+            "Version",
+            "Min Runtime",
+            "Max Runtime",
+            "SGM Runtime",
+            "SGM Memory",
+            "Solved Benchmarks",
+        ]
     ]
 
     # Sort by SGM Runtime

--- a/website/home.py
+++ b/website/home.py
@@ -24,40 +24,6 @@ solvers = df["Solver"].unique()
 solvers_count = len(solvers)
 unique_solver_versions_count = len(df[["Solver", "Solver Version"]].drop_duplicates())
 
-benchmarks = df["Benchmark"].unique()
-benchmarks_count = len(benchmarks)
-
-# Calculate the unique benchmark-size combinations
-unique_benchmark_sizes = df[["Benchmark", "Size"]].drop_duplicates()
-sizes_count = len(unique_benchmark_sizes)
-
-# TODO: Retrieve this information (e.g., timeout, numCPUs, RAM, etc.) directly from the benchmark runner.
-# Calculate the timeout from TO benchmarks
-timeout_seconds = df[df["Status"] == "TO"]["Runtime (s)"].max()
-timeout_seconds = timeout_seconds if not pd.isna(timeout_seconds) else 60
-timeout_readable = humanize.precisedelta(timeout_seconds, minimum_unit="seconds")
-# Title of the app
-st.title("OET/BE Solver Benchmark")
-
-st.markdown(
-    f"""
-    This website is an open-source benchmark of LP/MILP solvers on representative problems from the energy planning domain.
-    The website aims to help energy system modelers decide the best solver for their application; solver developers improve their solvers using realistic and important examples; and funders accelerate the green transition by giving them reliable metrics to evaluate solver performance over time.
-    We accept community contributions for new benchmarks, new / updated solver versions, and feedback on the benchmarking methodology and metrics via our [GitHub repository](https://github.com/orgs/open-energy-transition/solver-benchmark).
-
-    This project was developed by [Open Energy Transition](https://openenergytransition.org/), with funding from [Breakthrough Energy](https://www.breakthroughenergy.org/).
-
-    | **Details** | |
-    | ------------- | ------------- |
-    | **Solvers** | {solvers_count} ({unique_solver_versions_count}, including versions) |
-    | **Benchmarks** | {benchmarks_count} ({sizes_count}, including sizes) |
-    | **Timeout** | {timeout_readable} |
-    | **vCPU** | 2 (1 core) |
-    | **Memory** | 8GB |
-    """
-)
-
-
 # Filter
 filtered_metadata = generate_filtered_metadata(metadata_df)
 
@@ -188,14 +154,49 @@ def combine_sgm_tables(df):
     return combined_df
 
 
+# Calculate the unique benchmark-size combinations
+benchmarks = df["Benchmark"].unique()
+benchmarks_count = len(benchmarks)
+
+sizes_count = len(df.drop_duplicates(subset=["Size", "Benchmark"], keep="first"))
+
+# TODO: Retrieve this information (e.g., timeout, numCPUs, RAM, etc.) directly from the benchmark runner.
+# Calculate the timeout from TO benchmarks
+timeout_seconds = df[df["Status"] == "TO"]["Runtime (s)"].max()
+timeout_seconds = timeout_seconds if not pd.isna(timeout_seconds) else 60
+timeout_readable = humanize.precisedelta(timeout_seconds, minimum_unit="seconds")
+# Title of the app
+st.title("OET/BE Solver Benchmark")
+
+st.markdown(
+    f"""
+    This website is an open-source benchmark of LP/MILP solvers on representative problems from the energy planning domain.
+    The website aims to help energy system modelers decide the best solver for their application; solver developers improve their solvers using realistic and important examples; and funders accelerate the green transition by giving them reliable metrics to evaluate solver performance over time.
+    We accept community contributions for new benchmarks, new / updated solver versions, and feedback on the benchmarking methodology and metrics via our [GitHub repository](https://github.com/orgs/open-energy-transition/solver-benchmark).
+
+    This project was developed by [Open Energy Transition](https://openenergytransition.org/), with funding from [Breakthrough Energy](https://www.breakthroughenergy.org/).
+
+    | **Details** | |
+    | ------------- | ------------- |
+    | **Solvers** | {solvers_count} ({unique_solver_versions_count}, including versions) |
+    | **Benchmarks** | {benchmarks_count} ({sizes_count}, including sizes) |
+    | **Timeout** | {timeout_readable} |
+    | **vCPU** | 2 (1 core) |
+    | **Memory** | 8GB |
+    """
+)
+
+
 if not df.empty:
     # Generate the Combined Table
     sgm_combined_df = combine_sgm_tables(df)
 
     # Display the Combined Table
-    st.subheader("Results")
+    st.subheader("Results:")
+    st.write(
+        f"Solved benchmarks is the number of benchmarks where the solver returns an ok status, out of {sizes_count} benchmarks"
+    )
     st.table(sgm_combined_df)
-
 
 # Render scatter plot
 render_benchmark_scatter_plot(df, metadata, key="home_scatter_plot")

--- a/website/home.py
+++ b/website/home.py
@@ -114,8 +114,16 @@ def combine_sgm_tables(df):
         sgm_runtime = calculate_sgm(runtime_values)
 
         # Calculate Min and Max Runtime
-        min_runtime = str(round(runtime_values.min(), 1))
-        max_runtime = str(round(runtime_values.max(), 1))
+        min_runtime = runtime_values.min()
+
+        # Exclude TO values for max_runtime based on runtime and status
+        runtime_status = group[["Runtime (s)", "Status"]]
+        valid_runtimes = runtime_status[runtime_status["Status"] == "ok"]["Runtime (s)"]
+        max_runtime = (
+            (valid_runtimes.max())
+            if not valid_runtimes.empty
+            else "No valid max runtime"
+        )
 
         # Calculate the number of benchmarks solved
         solved_benchmarks = len(group[group["Status"] == "ok"])


### PR DESCRIPTION
Test result:
New result CSV with the latest HiGHS run time
[2024-12-11T08-31_export_with_highs_run_time.csv](https://github.com/user-attachments/files/18092579/2024-12-11T08-31_export_with_highs_run_time.csv)



|FIELD1|Benchmark                                                      |Size    |Solver|Solver Version|Solver Release Year|Status |Termination Condition|Runtime (s)       |Memory Usage (MB)|Objective Value   |Max Integrality Violation|Duality Gap             |highs_run_time    |
|------|---------------------------------------------------------------|--------|------|--------------|-------------------|-------|---------------------|------------------|-----------------|------------------|-------------------------|------------------------|------------------|
|101   |Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon12_Day29 |1-1h    |glpk  |5.0           |2020               |warning|unknown              |60                |8192             |                  |                         |                        |60                |
|102   |Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon12_Day314|1-1h    |glpk  |5.0           |2020               |warning|unknown              |60                |8192             |                  |                         |                        |60                |
|103   |Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon12_Day332|1-1h    |glpk  |5.0           |2020               |warning|unknown              |60                |8192             |                  |                         |                        |21.268036365509033|
.........
|880   |tulipa-1_EU_investment_simple                                  |28-672h |scip  |9.1.1         |2024               |TO     |Timeout              |60                |8192             |                  |                         |                        |60                |
|882   |tulipa-1_EU_investment_simple                                  |28-2016h|scip  |9.1.1         |2024               |TO     |Timeout              |60                |8192             |                  |                         |                        |60                |
|884   |tulipa-1_EU_investment_simple                                  |28-4032h|scip  |9.1.1         |2024               |TO     |Timeout              |60                |8192             |                  |                         |                        |60                |
|886   |tulipa-1_EU_investment_simple                                  |28-8760h|scip  |9.1.1         |2024               |TO     |Timeout              |60                |8192             |                  |                         |                        |60                |

When we add a filter for size, such as showing only XXS, it will become...

|FIELD1|Benchmark                                                      |Size    |Solver|Solver Version|Solver Release Year|Status |Termination Condition|Runtime (s)       |Memory Usage (MB)|Objective Value   |Max Integrality Violation|Duality Gap             |highs_run_time    |
|------|---------------------------------------------------------------|--------|------|--------------|-------------------|-------|---------------------|------------------|-----------------|------------------|-------------------------|------------------------|------------------|
|86    |genx-7_three_zones_w_colocated_VRE_storage                     |3-24h   |glpk  |5.0           |2020               |warning|unknown              |60                |8192             |                  |                         |                        |0.4413185119628906|
|36    |pypsa-eur-elec-op                                              |2-24h   |glpk  |5.0           |2020               |ok     |optimal              |6.36882758140564  |137.076          |7269027498        |                         |                        |1.224797248840332 |
|37    |pypsa-eur-elec-op                                              |3-24h   |glpk  |5.0           |2020               |ok     |optimal              |17.552338123321533|154.268          |7346414429        |                         |                        |3.970861196517944 |
|38    |pypsa-eur-elec-op                                              |2-12h   |glpk  |5.0           |2020               |ok     |optimal              |30.239359378814697|174.064          |7389777942        |                         |                        |5.883429288864136 |
|14    |pypsa-eur-elec-trex                                            |2-24h   |glpk  |5.0           |2020               |ok     |optimal              |6.441955327987671 |136.976          |7269143813        |                         |                        |1.790940284729004 |
|15    |pypsa-eur-elec-trex                                            |3-24h   |glpk  |5.0           |2020               |ok     |optimal              |19.342355012893677|154.192          |7250311849        |                         |                        |6.746302843093872 |
|78    |pypsa-gas+wind+sol+ely                                         |1-1h    |glpk  |5.0           |2020               |TO     |Timeout              |60                |8192             |                  |                         |                        |6.2434680461883545|
|95    |tulipa-1_EU_investment_simple                                  |28-24h  |glpk  |5.0           |2020               |warning|unknown              |60                |8192             |                  |                         |                        |8.176160335540771 |
|857   |genx-7_three_zones_w_colocated_VRE_storage                     |3-24h   |highs |1.8.1         |2024               |ok     |optimal              |0.4413185119628906|138.312          |443334.430587612  |0.499681269698442        |0.0000056893869610606685|0.4413185119628906|
|757   |pypsa-eur-elec-op                                              |2-24h   |highs |1.8.1         |2024               |ok     |optimal              |1.224797248840332 |196.712          |7269027497.86813  |                         |                        |1.224797248840332 |
|759   |pypsa-eur-elec-op                                              |3-24h   |highs |1.8.1         |2024               |ok     |optimal              |3.970861196517944 |248.24           |7346414429.227344 |                         |                        |3.970861196517944 |
|761   |pypsa-eur-elec-op                                              |2-12h   |highs |1.8.1         |2024               |ok     |optimal              |5.883429288864136 |279.06           |7389777941.591801 |                         |                        |5.883429288864136 |
|713   |pypsa-eur-elec-trex                                            |2-24h   |highs |1.8.1         |2024               |ok     |optimal              |1.790940284729004 |199.572          |7269143813.066846 |                         |                        |1.790940284729004 |
|715   |pypsa-eur-elec-trex                                            |3-24h   |highs |1.8.1         |2024               |ok     |optimal              |6.746302843093872 |254.488          |7250311849.251861 |                         |                        |6.746302843093872 |
|841   |pypsa-gas+wind+sol+ely                                         |1-1h    |highs |1.8.1         |2024               |ok     |optimal              |6.2434680461883545|422.72           |31714138111.86105 |                         |                        |6.2434680461883545|
|875   |tulipa-1_EU_investment_simple                                  |28-24h  |highs |1.8.1         |2024               |ok     |optimal              |8.176160335540771 |206.452          |223314143.52914777|0.5                      |0.00009676663361641652  |8.176160335540771 |
|858   |genx-7_three_zones_w_colocated_VRE_storage                     |3-24h   |scip  |9.1.1         |2024               |ok     |optimal              |3.213060140609741 |232.316          |443334.4305876122 |0.499943913150048        |0                       |0.4413185119628906|
|758   |pypsa-eur-elec-op                                              |2-24h   |scip  |9.1.1         |2024               |ok     |optimal              |2.8956098556518555|270.608          |7269027497.868132 |                         |                        |1.224797248840332 |
|760   |pypsa-eur-elec-op                                              |3-24h   |scip  |9.1.1         |2024               |ok     |optimal              |15.086172819137571|355.332          |7346414429.227432 |                         |                        |3.970861196517944 |
|762   |pypsa-eur-elec-op                                              |2-12h   |scip  |9.1.1         |2024               |ok     |optimal              |15.212609767913818|423.084          |7389777941.591944 |                         |                        |5.883429288864136 |
|714   |pypsa-eur-elec-trex                                            |2-24h   |scip  |9.1.1         |2024               |ok     |optimal              |4.4813501834869385|276.036          |7269143813.066574 |                         |                        |1.790940284729004 |
|716   |pypsa-eur-elec-trex                                            |3-24h   |scip  |9.1.1         |2024               |ok     |optimal              |12.085017681121826|354.912          |7250311849.251635 |                         |                        |6.746302843093872 |
|842   |pypsa-gas+wind+sol+ely                                         |1-1h    |scip  |9.1.1         |2024               |TO     |Timeout              |60                |8192             |                  |                         |                        |6.2434680461883545|
|876   |tulipa-1_EU_investment_simple                                  |28-24h  |scip  |9.1.1         |2024               |ok     |optimal              |8.024469375610352 |209.644          |223310171.76019543|0.5                      |0                       |8.176160335540771 |

We will have 5 GLPK, 8 HiGHS, and 7 SCIP instances with an OK status.
![image](https://github.com/user-attachments/assets/046c7a7e-090c-488f-9847-60b3508e693d)

