### PR TITLE
update benchmark_config

### DIFF
--- a/benchmarks/benchmark_config.yaml
+++ b/benchmarks/benchmark_config.yaml
@@ -162,14 +162,26 @@
     url: https://storage.googleapis.com/solver-benchmarks/pypsa-eur-elec-op-ucconv-3-3h.lp
   - size: 2-1h
     url: https://storage.googleapis.com/solver-benchmarks/pypsa-eur-elec-op-ucconv-2-1h.lp
-- name: pypsa-gas+wind+sol+ely
+- name: pypsa-power+ely+battery-1-1h
   sizes:
   - size: 1-1h
-    url: https://drive.usercontent.google.com/download?id=1fEiHuIwIxbkeu-QLuOZV2yeTeH3O1zbm&export=download&authuser=0&confirm=t
-- name: pypsa-gas+wind+sol+ely-ucgas
+    url: https://storage.googleapis.com/solver-benchmarks/pypsa-power%2Bely%2Bbattery-ucgas-1-1h.lp
+- name: pypsa-power+ely+battery-ucgas-1-1h
   sizes:
   - size: 1-1h
-    url: https://drive.usercontent.google.com/download?id=11jEBh4ypLqRgnP5DsQ2NkZomU4FjnDRU&export=download&authuser=0&confirm=t
+    url: https://storage.googleapis.com/solver-benchmarks/pypsa-power%2Bely%2Bbattery-ucgas-1-1h.lp
+- name: pypsa-power+ely-1-1h
+  sizes:
+  - size: 1-1h
+    url: https://storage.googleapis.com/solver-benchmarks/pypsa-power%2Bely-1-1h.lp
+- name: pypsa-power+ely-co2-1-1h
+  sizes:
+  - size: 1-1h
+    url: https://storage.googleapis.com/solver-benchmarks/pypsa-power%2Bely-co2-1-1h.lp
+- name: pypsa-power+ely-ucgas-1-1h
+  sizes:
+  - size: 1-1h
+    url: https://storage.googleapis.com/solver-benchmarks/pypsa-power%2Bely-ucgas-1-1h.lp
 - name: genx-1_three_zones
   sizes:
     - size: 3-1h
@@ -388,3 +400,55 @@
   sizes:
   - size: 1-1h
     url: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon48_Day332-c5f9c340dae227b689ac284a47d285373a0cd023658a17e9e56bc68136fad3de.mps.gz
+- name: genx-15-zones_elec_co2_uc
+  sizes:
+  - size: 15-168h
+    url: https://storage.googleapis.com/solver-benchmarks/genx-15-zones_elec_co2_uc.lp
+- name: genx-15-zones_elec_trex
+  sizes:
+  - size: 15-168h
+    url: https://storage.googleapis.com/solver-benchmarks/genx-15-zones_elec_trex.lp
+- name: genx-15-zones_elec_trex_co2
+  sizes:
+  - size: 15-168h
+    url: https://storage.googleapis.com/solver-benchmarks/genx-15-zones_elec_trex_co2.lp
+- name: genx-15-zones_elec_trex_co2_uc
+  sizes:
+  - size: 15-168h
+    url: https://storage.googleapis.com/solver-benchmarks/genx-15-zones_elec_trex_co2_uc.lp
+- name: genx-15-zones_elec_trex_uc
+  sizes:
+  - size: 15-168h
+    url: https://storage.googleapis.com/solver-benchmarks/genx-15-zones_elec_trex_uc.lp
+- name: genx-15-zones_elec_uc
+  sizes:
+  - size: 15-168h
+    url: https://storage.googleapis.com/solver-benchmarks/genx-15-zones_elec_uc.lp
+- name: genx_15-zones_elec_co2
+  sizes:
+  - size: 15-168h
+    url: https://storage.googleapis.com/solver-benchmarks/genx_15-zones_elec_co2.lp
+- name: temoa-US_9R_TS
+  sizes:
+  - size: 9-12
+    url: https://storage.googleapis.com/solver-benchmarks/temoa-US_9R_TS.lp
+- name: temoa-US_9R_TS_NDC
+  sizes:
+  - size: 9-12
+    url: https://storage.googleapis.com/solver-benchmarks/temoa-US_9R_TS_NDC.lp
+- name: temoa-US_9R_TS_NZ
+  sizes:
+  - size: 9-12
+    url: https://storage.googleapis.com/solver-benchmarks/temoa-US_9R_TS_NZ.lp
+- name: temoa-US_9R_TS_NZ_trunc_4periods
+  sizes:
+  - size: 9-12
+    url: https://storage.googleapis.com/solver-benchmarks/temoa-US_9R_TS_NZ_trunc_4periods.lp
+- name: temoa-US_9R_TS_SP
+  sizes:
+  - size: 9-12
+    url: https://storage.googleapis.com/solver-benchmarks/temoa-US_9R_TS_SP.lp
+- name: temoa-utopia
+  sizes:
+  - size: 1-6
+    url: https://storage.googleapis.com/solver-benchmarks/temoa-utopia.lp

--- a/benchmarks/benchmark_config.yaml
+++ b/benchmarks/benchmark_config.yaml
@@ -165,7 +165,7 @@
 - name: pypsa-power+ely+battery-1-1h
   sizes:
   - size: 1-1h
-    url: https://storage.googleapis.com/solver-benchmarks/pypsa-power%2Bely%2Bbattery-ucgas-1-1h.lp
+    url: https://storage.googleapis.com/solver-benchmarks/pypsa-power%2Bely%2Bbattery-1-1h.lp
 - name: pypsa-power+ely+battery-ucgas-1-1h
   sizes:
   - size: 1-1h
@@ -182,6 +182,26 @@
   sizes:
   - size: 1-1h
     url: https://storage.googleapis.com/solver-benchmarks/pypsa-power%2Bely-ucgas-1-1h.lp
+- name: pypsa-power+ely+battery-mod-1-1h
+  sizes:
+  - size: 1-1h
+    url: https://storage.googleapis.com/solver-benchmarks/pypsa-power%2Bely%2Bbattery-mod-1-1h.lp
+- name: pypsa-power+ely+battery-ucgas-mod-1-1h
+  sizes:
+  - size: 1-1h
+    url: https://storage.googleapis.com/solver-benchmarks/pypsa-power%2Bely%2Bbattery-ucgas-mod-1-1h.lp
+- name: pypsa-power+ely-mod-1-1h
+  sizes:
+  - size: 1-1h
+    url: https://storage.googleapis.com/solver-benchmarks/pypsa-power%2Bely-mod-1-1h.lp
+- name: pypsa-power+ely-co2-mod-1-1h
+  sizes:
+  - size: 1-1h
+    url: https://storage.googleapis.com/solver-benchmarks/pypsa-power%2Bely-co2-mod-1-1h.lp
+- name: pypsa-power+ely-ucgas-mod-1-1h
+  sizes:
+  - size: 1-1h
+    url: https://storage.googleapis.com/solver-benchmarks/pypsa-power%2Bely-ucgas-mod-1-1h.lp
 - name: genx-1_three_zones
   sizes:
     - size: 3-1h


### PR DESCRIPTION
Hi @siddharth-krishna here is the updated `benchmark_config.yaml` with all the new benchmark files. I used the public URL on GCP. Also, the files `pypsa-gas+wind+sol+ely-1-1h.lp` and `pypsa-gas+wind+sol+ely-1-1h-ucgas.lp` can be removed from there.
Concerning temoa benchmarks, sizes are not reported with the format `x-xh` because temoa doesn't work with hourly resolutions. Hope that's not an issue, otherwise we can use a temporary placeholder for that.