### PR TITLE
Add CBC solver; update linopy version

### DIFF
--- a/runner/envs/benchmark-2020-fixed.yaml
+++ b/runner/envs/benchmark-2020-fixed.yaml
@@ -2,83 +2,83 @@ name: benchmark-2020
 channels:
   - conda-forge
   - https://conda.anaconda.org/gurobi
-  - defaults
+  - nodefaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
-  - bottleneck=1.4.2=py312hc0a28a1_0
-  - brotli-python=1.1.0=py312h2ec8cdc_2
+  - brotli-python=1.1.0=py313h46c70d0_2
   - bzip2=1.0.8=h4bc722e_7
-  - ca-certificates=2024.8.30=hbcca054_0
-  - certifi=2024.8.30=pyhd8ed1ab_0
-  - cffi=1.17.1=py312h06ac9bb_0
-  - charset-normalizer=3.4.0=pyhd8ed1ab_0
-  - click=8.1.7=unix_pyh707e725_0
-  - cloudpickle=3.1.0=pyhd8ed1ab_1
-  - colorama=0.4.6=pyhd8ed1ab_0
-  - dask-core=2024.11.2=pyhff2d567_1
-  - deprecation=2.1.0=pyh9f0ad1d_0
-  - fsspec=2024.10.0=pyhff2d567_0
+  - ca-certificates=2025.1.31=hbcca054_0
+  - certifi=2025.1.31=pyhd8ed1ab_0
+  - cffi=1.17.1=py313hfab6e84_0
+  - charset-normalizer=3.4.1=pyhd8ed1ab_0
+  - coin-or-cbc=2.10.5=h9c3ff4c_6
+  - coin-or-cgl=0.60.9=h1d3f3f2_0
+  - coin-or-clp=1.17.10=h07f2a63_0
+  - coin-or-osi=0.108.11=h6514dde_1
+  - coin-or-utils=2.11.12=h99da652_1
   - glpk=5.0=h445213a_0
   - gmp=6.3.0=hac33072_2
-  - h2=4.1.0=pyhd8ed1ab_0
-  - hpack=4.0.0=pyh9f0ad1d_0
-  - hyperframe=6.0.1=pyhd8ed1ab_0
-  - idna=3.10=pyhd8ed1ab_0
-  - importlib-metadata=8.5.0=pyha770c72_0
+  - h2=4.2.0=pyhd8ed1ab_0
+  - hpack=4.1.0=pyhd8ed1ab_0
+  - hyperframe=6.1.0=pyhd8ed1ab_0
+  - idna=3.10=pyhd8ed1ab_1
   - ld_impl_linux-64=2.43=h712a8e2_2
-  - libblas=3.9.0=25_linux64_openblas
-  - libcblas=3.9.0=25_linux64_openblas
+  - libblas=3.9.0=28_h59b9bed_openblas
+  - libcblas=3.9.0=28_he106b2a_openblas
   - libexpat=2.6.4=h5888daf_0
-  - libffi=3.4.2=h7f98852_5
+  - libffi=3.4.6=h2dba641_0
   - libgcc=14.2.0=h77fa898_1
   - libgcc-ng=14.2.0=h69a702a_1
   - libgfortran=14.2.0=h69a702a_1
+  - libgfortran-ng=14.2.0=h69a702a_1
   - libgfortran5=14.2.0=hd5240d6_1
   - libgomp=14.2.0=h77fa898_1
-  - liblapack=3.9.0=25_linux64_openblas
-  - libnsl=2.0.1=hd590300_0
+  - liblapack=3.9.0=28_h7ac8fdf_openblas
+  - liblapacke=3.9.0=28_he2f377e_openblas
+  - liblzma=5.6.4=hb9d3cd8_0
+  - libmpdec=4.0.0=h4bc722e_0
   - libopenblas=0.3.28=pthreads_h94d23a6_1
-  - libsqlite=3.47.0=hadc24fc_1
+  - libsqlite=3.48.0=hee588c1_1
   - libstdcxx=14.2.0=hc0a3c3a_1
   - libstdcxx-ng=14.2.0=h4852527_1
   - libuuid=2.38.1=h0b41bf4_0
-  - libxcrypt=4.4.36=hd590300_1
   - libzlib=1.3.1=hb9d3cd8_2
-  - linopy=0.4.2=pyhff2d567_0
-  - locket=1.0.0=pyhd8ed1ab_0
-  - ncurses=6.5=he02047a_1
-  - nomkl=1.0=h5ca1d4c_0
-  - numexpr=2.10.1=py312h6a710ac_103
-  - numpy=1.26.4=py312heda63a1_0
-  - openssl=3.4.0=hb9d3cd8_0
-  - packaging=24.2=pyhff2d567_1
-  - pandas=2.2.3=py312hf9745cd_1
-  - partd=1.4.2=pyhd8ed1ab_0
-  - pip=24.3.1=pyh8b19718_0
-  - polars=1.12.0=py312hfe7c9be_1
-  - pycparser=2.22=pyhd8ed1ab_0
-  - pysocks=1.7.1=pyha2e5f31_6
-  - python=3.12.7=hc5c86c4_0_cpython
-  - python-dateutil=2.9.0.post0=pyhff2d567_0
-  - python-tzdata=2024.2=pyhd8ed1ab_0
-  - python_abi=3.12=5_cp312
-  - pytz=2024.1=pyhd8ed1ab_0
-  - pyyaml=6.0.2=py312h66e93f0_1
+  - ncurses=6.5=h2d0b736_3
+  - openssl=3.4.1=h7b32b05_0
+  - pip=25.0.1=pyh145f28c_0
+  - pycparser=2.22=pyh29332c3_1
+  - pysocks=1.7.1=pyha55dd90_7
+  - python=3.13.2=hf636f53_100_cp313
+  - python_abi=3.13=5_cp313
   - readline=8.2=h8228510_1
-  - requests=2.32.3=pyhd8ed1ab_0
-  - scipy=1.14.1=py312h62794b6_1
-  - setuptools=75.6.0=pyhff2d567_0
-  - six=1.16.0=pyh6c4a22f_0
+  - requests=2.32.3=pyhd8ed1ab_1
   - tk=8.6.13=noxft_h4845f30_101
-  - toolz=1.0.0=pyhd8ed1ab_0
-  - tqdm=4.67.0=pyhd8ed1ab_0
-  - tzdata=2024b=hc8b5060_0
-  - urllib3=2.2.3=pyhd8ed1ab_0
-  - wheel=0.45.0=pyhd8ed1ab_0
-  - xarray=2024.10.0=pyhd8ed1ab_0
-  - xz=5.2.6=h166bdaf_0
-  - yaml=0.2.5=h7f98852_2
-  - zipp=3.21.0=pyhd8ed1ab_0
-  - zstandard=0.23.0=py312hef9b889_1
+  - urllib3=2.3.0=pyhd8ed1ab_0
+  - zstandard=0.23.0=py313h80202fe_1
   - zstd=1.5.6=ha6fb4c9_0
+  - pip:
+      - bottleneck==1.4.2
+      - click==8.1.8
+      - cloudpickle==3.1.1
+      - dask==2025.2.0
+      - deprecation==2.1.0
+      - fsspec==2025.2.0
+      - linopy==0.5.0
+      - locket==1.0.0
+      - numexpr==2.10.2
+      - numpy==1.26.4
+      - packaging==24.2
+      - pandas==2.2.3
+      - partd==1.4.2
+      - polars==1.22.0
+      - python-dateutil==2.9.0.post0
+      - pytz==2025.1
+      - pyyaml==6.0.2
+      - scipy==1.15.1
+      - six==1.17.0
+      - toolz==1.0.0
+      - tqdm==4.67.1
+      - tzdata==2025.1
+      - xarray==2025.1.2
+prefix: /scratch/htc/skrishna/conda/envs/benchmark-2020

--- a/runner/envs/benchmark-2020.yaml
+++ b/runner/envs/benchmark-2020.yaml
@@ -7,12 +7,15 @@ dependencies:
 - python>=3.9
 - pip
 
-- linopy>=0.4.1
 - requests>=2.32
 
+- coin-or-cbc==2.10.5
 # - scip==7.0.2 # TODO errors with AttributeError: 'pyscipopt.scip.Model' object has no attribute 'getDualSolVal'
 # - pyscipopt==3.1.0
 - glpk==5.0.0
 # - gurobi==9.1.1  # TODO needs py<39 but linopy needs py>39
 
 # HiGHS was released first in 2021 so it is omitted here
+
+- pip:
+  - linopy>=0.5.0

--- a/runner/envs/benchmark-2021-fixed.yaml
+++ b/runner/envs/benchmark-2021-fixed.yaml
@@ -2,81 +2,68 @@ name: benchmark-2021
 channels:
   - conda-forge
   - https://conda.anaconda.org/gurobi
-  - defaults
+  - nodefaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
-  - bottleneck=1.4.2=py312hc0a28a1_0
-  - brotli-python=1.1.0=py312h2ec8cdc_2
+  - brotli-python=1.1.0=py313h46c70d0_2
   - bzip2=1.0.8=h4bc722e_7
-  - ca-certificates=2024.8.30=hbcca054_0
-  - certifi=2024.8.30=pyhd8ed1ab_0
-  - cffi=1.17.1=py312h06ac9bb_0
-  - charset-normalizer=3.4.0=pyhd8ed1ab_0
-  - click=8.1.7=unix_pyh707e725_0
-  - cloudpickle=3.1.0=pyhd8ed1ab_1
-  - colorama=0.4.6=pyhd8ed1ab_0
-  - dask-core=2024.11.2=pyhff2d567_1
-  - deprecation=2.1.0=pyh9f0ad1d_0
-  - fsspec=2024.10.0=pyhff2d567_0
-  - h2=4.1.0=pyhd8ed1ab_0
-  - hpack=4.0.0=pyh9f0ad1d_0
-  - hyperframe=6.0.1=pyhd8ed1ab_0
-  - idna=3.10=pyhd8ed1ab_0
-  - importlib-metadata=8.5.0=pyha770c72_0
+  - ca-certificates=2025.1.31=hbcca054_0
+  - certifi=2025.1.31=pyhd8ed1ab_0
+  - cffi=1.17.1=py313hfab6e84_0
+  - charset-normalizer=3.4.1=pyhd8ed1ab_0
+  - h2=4.2.0=pyhd8ed1ab_0
+  - hpack=4.1.0=pyhd8ed1ab_0
+  - hyperframe=6.1.0=pyhd8ed1ab_0
+  - idna=3.10=pyhd8ed1ab_1
   - ld_impl_linux-64=2.43=h712a8e2_2
-  - libblas=3.9.0=25_linux64_openblas
-  - libcblas=3.9.0=25_linux64_openblas
   - libexpat=2.6.4=h5888daf_0
-  - libffi=3.4.2=h7f98852_5
+  - libffi=3.4.6=h2dba641_0
   - libgcc=14.2.0=h77fa898_1
   - libgcc-ng=14.2.0=h69a702a_1
-  - libgfortran=14.2.0=h69a702a_1
-  - libgfortran5=14.2.0=hd5240d6_1
   - libgomp=14.2.0=h77fa898_1
-  - liblapack=3.9.0=25_linux64_openblas
-  - libnsl=2.0.1=hd590300_0
-  - libopenblas=0.3.28=pthreads_h94d23a6_1
-  - libsqlite=3.47.0=hadc24fc_1
+  - liblzma=5.6.4=hb9d3cd8_0
+  - libmpdec=4.0.0=h4bc722e_0
+  - libsqlite=3.48.0=hee588c1_1
   - libstdcxx=14.2.0=hc0a3c3a_1
   - libstdcxx-ng=14.2.0=h4852527_1
   - libuuid=2.38.1=h0b41bf4_0
-  - libxcrypt=4.4.36=hd590300_1
   - libzlib=1.3.1=hb9d3cd8_2
-  - linopy=0.4.2=pyhff2d567_0
-  - locket=1.0.0=pyhd8ed1ab_0
-  - ncurses=6.5=he02047a_1
-  - nomkl=1.0=h5ca1d4c_0
-  - numexpr=2.10.1=py312h6a710ac_103
-  - numpy=1.26.4=py312heda63a1_0
-  - openssl=3.4.0=hb9d3cd8_0
-  - packaging=24.2=pyhff2d567_1
-  - pandas=2.2.3=py312hf9745cd_1
-  - partd=1.4.2=pyhd8ed1ab_0
-  - pip=24.3.1=pyh8b19718_0
-  - polars=1.12.0=py312hfe7c9be_1
-  - pycparser=2.22=pyhd8ed1ab_0
-  - pysocks=1.7.1=pyha2e5f31_6
-  - python=3.12.7=hc5c86c4_0_cpython
-  - python-dateutil=2.9.0.post0=pyhff2d567_0
-  - python-tzdata=2024.2=pyhd8ed1ab_0
-  - python_abi=3.12=5_cp312
-  - pytz=2024.1=pyhd8ed1ab_0
-  - pyyaml=6.0.2=py312h66e93f0_1
+  - ncurses=6.5=h2d0b736_3
+  - openssl=3.4.1=h7b32b05_0
+  - pip=25.0.1=pyh145f28c_0
+  - pycparser=2.22=pyh29332c3_1
+  - pysocks=1.7.1=pyha55dd90_7
+  - python=3.13.2=hf636f53_100_cp313
+  - python_abi=3.13=5_cp313
   - readline=8.2=h8228510_1
-  - requests=2.32.3=pyhd8ed1ab_0
-  - scipy=1.14.1=py312h62794b6_1
-  - setuptools=75.6.0=pyhff2d567_0
-  - six=1.16.0=pyh6c4a22f_0
+  - requests=2.32.3=pyhd8ed1ab_1
   - tk=8.6.13=noxft_h4845f30_101
-  - toolz=1.0.0=pyhd8ed1ab_0
-  - tqdm=4.67.0=pyhd8ed1ab_0
-  - tzdata=2024b=hc8b5060_0
-  - urllib3=2.2.3=pyhd8ed1ab_0
-  - wheel=0.45.0=pyhd8ed1ab_0
-  - xarray=2024.10.0=pyhd8ed1ab_0
-  - xz=5.2.6=h166bdaf_0
-  - yaml=0.2.5=h7f98852_2
-  - zipp=3.21.0=pyhd8ed1ab_0
-  - zstandard=0.23.0=py312hef9b889_1
+  - urllib3=2.3.0=pyhd8ed1ab_0
+  - zstandard=0.23.0=py313h80202fe_1
   - zstd=1.5.6=ha6fb4c9_0
+  - pip:
+      - bottleneck==1.4.2
+      - click==8.1.8
+      - cloudpickle==3.1.1
+      - dask==2025.2.0
+      - deprecation==2.1.0
+      - fsspec==2025.2.0
+      - linopy==0.5.0
+      - locket==1.0.0
+      - numexpr==2.10.2
+      - numpy==1.26.4
+      - packaging==24.2
+      - pandas==2.2.3
+      - partd==1.4.2
+      - polars==1.22.0
+      - python-dateutil==2.9.0.post0
+      - pytz==2025.1
+      - pyyaml==6.0.2
+      - scipy==1.15.1
+      - six==1.17.0
+      - toolz==1.0.0
+      - tqdm==4.67.1
+      - tzdata==2025.1
+      - xarray==2025.1.2
+prefix: /scratch/htc/skrishna/conda/envs/benchmark-2021

--- a/runner/envs/benchmark-2021.yaml
+++ b/runner/envs/benchmark-2021.yaml
@@ -7,7 +7,6 @@ dependencies:
 - python>=3.9
 - pip
 
-- linopy>=0.4.1
 - requests>=2.32
 
 # - scip==7.0.3  # TODO errors with AttributeError: 'pyscipopt.scip.Model' object has no attribute 'getDualSolVal'
@@ -15,3 +14,6 @@ dependencies:
 # - gurobi==9.5.0  # TODO this doesn't work with py39 but linopy needs py39
 
 # TODO highspy 1.1.1 wasn't released to PyPI, and had no setup.py/pyproject.toml so couldn't install via conda or pip, so omitted..
+
+- pip:
+  - linopy>=0.5.0

--- a/runner/envs/benchmark-2022-fixed.yaml
+++ b/runner/envs/benchmark-2022-fixed.yaml
@@ -3,48 +3,47 @@ channels:
   - gurobi
   - conda-forge
   - https://conda.anaconda.org/gurobi
-  - defaults
+  - nodefaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
-  - _openmp_mutex=4.5=2_gnu
+  - _openmp_mutex=4.5=2_kmp_llvm
   - ampl-mp=3.1.0=h2cc385e_1006
-  - bottleneck=1.4.2=py310hf462985_0
   - brotli-python=1.1.0=py310hf71b8c6_2
   - bzip2=1.0.8=h4bc722e_7
-  - ca-certificates=2024.8.30=hbcca054_0
-  - certifi=2024.8.30=pyhd8ed1ab_0
+  - ca-certificates=2025.1.31=hbcca054_0
+  - certifi=2025.1.31=pyhd8ed1ab_0
   - cffi=1.17.1=py310h8deb56e_0
-  - charset-normalizer=3.4.0=pyhd8ed1ab_0
-  - click=8.1.7=unix_pyh707e725_0
-  - cloudpickle=3.1.0=pyhd8ed1ab_1
-  - colorama=0.4.6=pyhd8ed1ab_0
+  - charset-normalizer=3.4.1=pyhd8ed1ab_0
+  - coin-or-cbc=2.10.8=h3786ebc_0
+  - coin-or-cgl=0.60.7=h516709c_0
+  - coin-or-clp=1.17.8=h1ee7a9c_0
+  - coin-or-osi=0.108.10=haf5fa05_0
+  - coin-or-utils=2.11.11=hee58242_0
   - cppad=20230000.0=h59595ed_2
-  - dask-core=2024.11.2=pyhff2d567_1
-  - deprecation=2.1.0=pyh9f0ad1d_0
-  - fsspec=2024.10.0=pyhff2d567_0
   - gmp=6.3.0=hac33072_2
   - gurobi=10.0.0=py310_0
-  - h2=4.1.0=pyhd8ed1ab_0
-  - hpack=4.0.0=pyh9f0ad1d_0
-  - hyperframe=6.0.1=pyhd8ed1ab_0
+  - h2=4.2.0=pyhd8ed1ab_0
+  - hpack=4.1.0=pyhd8ed1ab_0
+  - hyperframe=6.1.0=pyhd8ed1ab_0
   - icu=73.2=h59595ed_0
-  - idna=3.10=pyhd8ed1ab_0
-  - importlib-metadata=8.5.0=pyha770c72_0
+  - idna=3.10=pyhd8ed1ab_1
   - ipopt=3.14.12=he6d3896_1
   - ld_impl_linux-64=2.43=h712a8e2_2
-  - libblas=3.9.0=25_linux64_openblas
-  - libcblas=3.9.0=25_linux64_openblas
-  - libedit=3.1.20191231=he28a2e2_2
-  - libffi=3.4.2=h7f98852_5
+  - libblas=3.9.0=29_h59b9bed_openblas
+  - libcblas=3.9.0=29_he106b2a_openblas
+  - libedit=3.1.20250104=pl5321h7949ede_0
+  - libffi=3.4.6=h2dba641_0
   - libgcc=14.2.0=h77fa898_1
   - libgcc-ng=14.2.0=h69a702a_1
   - libgfortran=14.2.0=h69a702a_1
   - libgfortran-ng=14.2.0=h69a702a_1
   - libgfortran5=14.2.0=hd5240d6_1
-  - libgomp=14.2.0=h77fa898_1
   - libhwloc=2.9.1=nocuda_h7313eea_6
   - libiconv=1.17=hd590300_2
-  - liblapack=3.9.0=25_linux64_openblas
+  - liblapack=3.9.0=29_h7ac8fdf_openblas
+  - liblapacke=3.9.0=29_he2f377e_openblas
+  - liblzma=5.6.4=hb9d3cd8_0
+  - liblzma-devel=5.6.4=hb9d3cd8_0
   - libnsl=2.0.1=hd590300_0
   - libopenblas=0.3.28=pthreads_h94d23a6_1
   - libspral=2023.08.02=h2baf039_0
@@ -55,55 +54,63 @@ dependencies:
   - libxcrypt=4.4.36=hd590300_1
   - libxml2=2.12.7=hc051c1a_1
   - libzlib=1.2.13=h4ab18f5_6
-  - linopy=0.4.2=pyhff2d567_0
-  - locket=1.0.0=pyhd8ed1ab_0
+  - llvm-openmp=19.1.7=h024ca30_0
   - metis=5.1.0=hd0bcaf9_1007
+  - mkl=2024.2.2=ha957f24_16
   - mumps-include=5.2.1=ha770c72_14
   - mumps-seq=5.2.1=h2104b81_11
-  - ncurses=6.5=he02047a_1
-  - nomkl=1.0=h5ca1d4c_0
-  - numexpr=2.10.1=py310hdb6e06b_103
-  - numpy=1.26.4=py310hb13e2d6_0
-  - openssl=3.4.0=hb9d3cd8_0
-  - packaging=24.2=pyhff2d567_1
-  - pandas=2.2.3=py310h5eaa309_1
-  - partd=1.4.2=pyhd8ed1ab_0
-  - pip=24.3.1=pyh8b19718_0
-  - polars=1.12.0=py310h4a863d9_1
-  - pycparser=2.22=pyhd8ed1ab_0
+  - ncurses=6.5=h2d0b736_3
+  - openssl=3.4.1=h7b32b05_0
+  - pip=25.0.1=pyh8b19718_0
+  - pycparser=2.22=pyh29332c3_1
   - pyscipopt=4.3.0=py310heca2aa9_0
-  - pysocks=1.7.1=pyha2e5f31_6
+  - pysocks=1.7.1=pyha55dd90_7
   - python=3.10.14=hd12c33a_0_cpython
-  - python-dateutil=2.9.0.post0=pyhff2d567_0
-  - python-tzdata=2024.2=pyhd8ed1ab_0
   - python_abi=3.10=5_cp310
-  - pytz=2024.1=pyhd8ed1ab_0
-  - pyyaml=6.0.2=py310ha75aee5_1
   - readline=8.2=h8228510_1
-  - requests=2.32.3=pyhd8ed1ab_0
+  - requests=2.32.3=pyhd8ed1ab_1
   - scip=8.0.3=h4a32fe0_2
-  - scipy=1.14.1=py310hfcf56fc_1
   - scotch=6.0.9=hb2e6521_2
-  - setuptools=75.6.0=pyhff2d567_0
-  - six=1.16.0=pyh6c4a22f_0
+  - setuptools=75.8.0=pyhff2d567_0
   - tbb=2021.9.0=hf52228f_0
   - tk=8.6.13=noxft_h4845f30_101
-  - toolz=1.0.0=pyhd8ed1ab_0
-  - tqdm=4.67.0=pyhd8ed1ab_0
-  - typing_extensions=4.12.2=pyha770c72_0
-  - tzdata=2024b=hc8b5060_0
   - unixodbc=2.3.12=h661eb56_0
-  - urllib3=2.2.3=pyhd8ed1ab_0
-  - wheel=0.45.0=pyhd8ed1ab_0
-  - xarray=2024.10.0=pyhd8ed1ab_0
-  - xz=5.2.6=h166bdaf_0
-  - yaml=0.2.5=h7f98852_2
-  - zipp=3.21.0=pyhd8ed1ab_0
+  - urllib3=2.3.0=pyhd8ed1ab_0
+  - wheel=0.45.1=pyhd8ed1ab_1
+  - xz=5.6.4=hbcc6ac9_0
+  - xz-gpl-tools=5.6.4=hbcc6ac9_0
+  - xz-tools=5.6.4=hb9d3cd8_0
   - zlib=1.2.13=h4ab18f5_6
   - zstandard=0.23.0=py310ha39cb0e_1
   - zstd=1.5.6=ha6fb4c9_0
   - pip:
+      - bottleneck==1.4.2
+      - click==8.1.8
+      - cloudpickle==3.1.1
+      - dask==2025.2.0
+      - deprecation==2.1.0
+      - fsspec==2025.2.0
       - highspy==1.5.0.dev0
+      - importlib-metadata==8.6.1
+      - linopy==0.5.0
+      - locket==1.0.0
+      - numexpr==2.10.2
+      - numpy==1.26.4
+      - packaging==24.2
+      - pandas==2.2.3
+      - partd==1.4.2
       - ply==3.11
+      - polars==1.22.0
       - pybind11==2.13.6
       - pyomo==6.8.2
+      - python-dateutil==2.9.0.post0
+      - pytz==2025.1
+      - pyyaml==6.0.2
+      - scipy==1.15.1
+      - six==1.17.0
+      - toolz==1.0.0
+      - tqdm==4.67.1
+      - tzdata==2025.1
+      - xarray==2025.1.2
+      - zipp==3.21.0
+prefix: /scratch/htc/skrishna/conda/envs/benchmark-2022

--- a/runner/envs/benchmark-2022.yaml
+++ b/runner/envs/benchmark-2022.yaml
@@ -7,12 +7,13 @@ dependencies:
 - python>=3.9
 - pip
 
-- linopy>=0.4.1
 - requests>=2.32
 
+- coin-or-cbc==2.10.8
 - scip==8.0.3
 - pyscipopt==4.3.0
 - gurobi==10.0.0
 
 - pip:
+  - linopy>=0.5.0
   - highspy==1.5.0.dev0

--- a/runner/envs/benchmark-2023-fixed.yaml
+++ b/runner/envs/benchmark-2023-fixed.yaml
@@ -6,101 +6,107 @@ channels:
   - nodefaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
-  - _openmp_mutex=4.5=2_gnu
+  - _openmp_mutex=4.5=2_kmp_llvm
   - ampl-mp=3.1.0=h2cc385e_1006
-  - bottleneck=1.4.2=py312hc0a28a1_0
   - brotli-python=1.1.0=py312h2ec8cdc_2
   - bzip2=1.0.8=h4bc722e_7
-  - ca-certificates=2024.8.30=hbcca054_0
-  - certifi=2024.8.30=pyhd8ed1ab_0
+  - ca-certificates=2025.1.31=hbcca054_0
+  - certifi=2025.1.31=pyhd8ed1ab_0
   - cffi=1.17.1=py312h06ac9bb_0
-  - charset-normalizer=3.4.0=pyhd8ed1ab_0
-  - click=8.1.7=unix_pyh707e725_0
-  - cloudpickle=3.1.0=pyhd8ed1ab_1
-  - colorama=0.4.6=pyhd8ed1ab_0
+  - charset-normalizer=3.4.1=pyhd8ed1ab_0
+  - coin-or-cbc=2.10.11=h56f689f_0
+  - coin-or-cgl=0.60.9=h1d3f3f2_0
+  - coin-or-clp=1.17.10=h07f2a63_0
+  - coin-or-osi=0.108.11=h6514dde_1
+  - coin-or-utils=2.11.12=h99da652_1
   - cppad=20240000.2=h59595ed_0
-  - dask-core=2024.11.2=pyhff2d567_1
-  - deprecation=2.1.0=pyh9f0ad1d_0
-  - fsspec=2024.10.0=pyhff2d567_0
   - gmp=6.3.0=hac33072_2
   - gurobi=11.0.0=py312_0
-  - h2=4.1.0=pyhd8ed1ab_0
-  - hpack=4.0.0=pyh9f0ad1d_0
-  - hyperframe=6.0.1=pyhd8ed1ab_0
-  - idna=3.10=pyhd8ed1ab_0
-  - importlib-metadata=8.5.0=pyha770c72_0
+  - h2=4.2.0=pyhd8ed1ab_0
+  - hpack=4.1.0=pyhd8ed1ab_0
+  - hyperframe=6.1.0=pyhd8ed1ab_0
+  - idna=3.10=pyhd8ed1ab_1
   - ipopt=3.14.14=h04b96a2_1
   - ld_impl_linux-64=2.43=h712a8e2_2
-  - libblas=3.9.0=25_linux64_openblas
-  - libcblas=3.9.0=25_linux64_openblas
-  - libedit=3.1.20191231=he28a2e2_2
+  - libblas=3.9.0=29_h59b9bed_openblas
+  - libcblas=3.9.0=29_he106b2a_openblas
+  - libedit=3.1.20250104=pl5321h7949ede_0
   - libexpat=2.6.4=h5888daf_0
-  - libffi=3.4.2=h7f98852_5
+  - libffi=3.4.6=h2dba641_0
   - libgcc=14.2.0=h77fa898_1
   - libgcc-ng=14.2.0=h69a702a_1
   - libgfortran=14.2.0=h69a702a_1
   - libgfortran-ng=14.2.0=h69a702a_1
   - libgfortran5=14.2.0=hd5240d6_1
-  - libgomp=14.2.0=h77fa898_1
   - libhwloc=2.9.3=default_h554bfaf_1009
   - libiconv=1.17=hd590300_2
-  - liblapack=3.9.0=25_linux64_openblas
+  - liblapack=3.9.0=29_h7ac8fdf_openblas
+  - liblapacke=3.9.0=29_he2f377e_openblas
+  - liblzma=5.6.4=hb9d3cd8_0
+  - liblzma-devel=5.6.4=hb9d3cd8_0
   - libnsl=2.0.1=hd590300_0
   - libopenblas=0.3.28=pthreads_h94d23a6_1
   - libscotch=7.0.4=h2fe6a88_5
   - libspral=2023.09.07=h6aa6db2_2
-  - libsqlite=3.47.0=hadc24fc_1
+  - libsqlite=3.48.0=hee588c1_1
   - libstdcxx=14.2.0=hc0a3c3a_1
   - libstdcxx-ng=14.2.0=h4852527_1
   - libuuid=2.38.1=h0b41bf4_0
   - libxcrypt=4.4.36=hd590300_1
-  - libxml2=2.13.5=h064dc61_0
+  - libxml2=2.13.5=h0d44e9d_1
   - libzlib=1.3.1=hb9d3cd8_2
-  - linopy=0.4.1=pyhff2d567_0
-  - locket=1.0.0=pyhd8ed1ab_0
+  - llvm-openmp=19.1.7=h024ca30_0
   - metis=5.1.0=hd0bcaf9_1007
+  - mkl=2024.2.2=ha957f24_16
   - mumps-include=5.6.2=ha770c72_4
   - mumps-seq=5.6.2=hfef103a_4
-  - ncurses=6.5=he02047a_1
-  - nomkl=1.0=h5ca1d4c_0
-  - numexpr=2.10.1=py312h6a710ac_103
-  - numpy=1.26.4=py312heda63a1_0
-  - openssl=3.4.0=hb9d3cd8_0
-  - packaging=24.2=pyhff2d567_1
-  - pandas=2.2.3=py312hf9745cd_1
-  - partd=1.4.2=pyhd8ed1ab_0
-  - pip=24.3.1=pyh8b19718_0
-  - polars=1.12.0=py312hfe7c9be_1
-  - pycparser=2.22=pyhd8ed1ab_0
+  - ncurses=6.5=h2d0b736_3
+  - openssl=3.4.1=h7b32b05_0
+  - pip=25.0.1=pyh8b19718_0
+  - pycparser=2.22=pyh29332c3_1
   - pyscipopt=4.4.0=py312h30efb56_1
-  - pysocks=1.7.1=pyha2e5f31_6
-  - python=3.12.7=hc5c86c4_0_cpython
-  - python-dateutil=2.9.0.post0=pyhff2d567_0
-  - python-tzdata=2024.2=pyhd8ed1ab_0
+  - pysocks=1.7.1=pyha55dd90_7
+  - python=3.12.9=h9e4cc4f_0_cpython
   - python_abi=3.12=5_cp312
-  - pytz=2024.1=pyhd8ed1ab_0
-  - pyyaml=6.0.2=py312h66e93f0_1
   - readline=8.2=h8228510_1
-  - requests=2.32.3=pyhd8ed1ab_0
+  - requests=2.32.3=pyhd8ed1ab_1
   - scip=8.1.0=h41ab4b8_7
-  - scipy=1.14.1=py312h62794b6_1
   - scotch=7.0.4=hd53efc5_5
-  - setuptools=75.5.0=pyhff2d567_0
-  - six=1.16.0=pyh6c4a22f_0
+  - setuptools=75.8.0=pyhff2d567_0
   - tbb=2021.11.0=h00ab1b0_1
   - tk=8.6.13=noxft_h4845f30_101
-  - toolz=1.0.0=pyhd8ed1ab_0
-  - tqdm=4.67.0=pyhd8ed1ab_0
-  - tzdata=2024b=hc8b5060_0
   - unixodbc=2.3.12=h661eb56_0
-  - urllib3=2.2.3=pyhd8ed1ab_0
-  - wheel=0.45.0=pyhd8ed1ab_0
-  - xarray=2024.10.0=pyhd8ed1ab_0
-  - xz=5.2.6=h166bdaf_0
-  - yaml=0.2.5=h7f98852_2
-  - zipp=3.21.0=pyhd8ed1ab_0
+  - urllib3=2.3.0=pyhd8ed1ab_0
+  - wheel=0.45.1=pyhd8ed1ab_1
+  - xz=5.6.4=hbcc6ac9_0
+  - xz-gpl-tools=5.6.4=hbcc6ac9_0
+  - xz-tools=5.6.4=hb9d3cd8_0
   - zlib=1.3.1=hb9d3cd8_2
   - zstandard=0.23.0=py312hef9b889_1
   - zstd=1.5.6=ha6fb4c9_0
   - pip:
-      - highspy==1.6.0.dev0
+      - bottleneck==1.4.2
+      - click==8.1.8
+      - cloudpickle==3.1.1
+      - dask==2025.2.0
+      - deprecation==2.1.0
+      - fsspec==2025.2.0
+      - git+https://github.com//ERGO-Code/HiGHS@v1.6.0
+      - linopy==0.5.0
+      - locket==1.0.0
+      - numexpr==2.10.2
+      - numpy==1.26.4
+      - packaging==24.2
+      - pandas==2.2.3
+      - partd==1.4.2
+      - polars==1.22.0
+      - python-dateutil==2.9.0.post0
+      - pytz==2025.1
+      - pyyaml==6.0.2
+      - scipy==1.15.1
+      - six==1.17.0
+      - toolz==1.0.0
+      - tqdm==4.67.1
+      - tzdata==2025.1
+      - xarray==2025.1.2
+prefix: /scratch/htc/skrishna/conda/envs/benchmark-2023

--- a/runner/envs/benchmark-2023.yaml
+++ b/runner/envs/benchmark-2023.yaml
@@ -7,12 +7,14 @@ dependencies:
 - python>=3.12
 - pip
 
-- linopy>=0.4.1
 - requests>=2.32
 
+- coin-or-cbc==2.10.11
 - scip==8.1.0
 - pyscipopt==4.4.0
 - gurobi==11.0.0
 
-# TODO highspy 1.6.0 wasn't released to PyPI! So installed with
-# pip install git+https://github.com//ERGO-Code/HiGHS@v1.6.0
+- pip:
+  - linopy>=0.5.0
+  # highspy 1.6.0 wasn't released to PyPI:
+  - git+https://github.com//ERGO-Code/HiGHS@v1.6.0

--- a/runner/envs/benchmark-2024-fixed.yaml
+++ b/runner/envs/benchmark-2024-fixed.yaml
@@ -6,101 +6,105 @@ channels:
   - nodefaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
-  - _openmp_mutex=4.5=2_gnu
-  - ampl-mp=3.1.0=h2cc385e_1006
-  - bottleneck=1.4.2=py312hc0a28a1_0
+  - _openmp_mutex=4.5=2_kmp_llvm
+  - ampl-asl=1.0.0=h5888daf_2
   - brotli-python=1.1.0=py312h2ec8cdc_2
   - bzip2=1.0.8=h4bc722e_7
-  - ca-certificates=2024.8.30=hbcca054_0
-  - certifi=2024.8.30=pyhd8ed1ab_0
+  - ca-certificates=2025.1.31=hbcca054_0
+  - certifi=2025.1.31=pyhd8ed1ab_0
   - cffi=1.17.1=py312h06ac9bb_0
-  - charset-normalizer=3.4.0=pyhd8ed1ab_0
-  - click=8.1.7=unix_pyh707e725_0
-  - cloudpickle=3.1.0=pyhd8ed1ab_1
-  - colorama=0.4.6=pyhd8ed1ab_0
-  - cppad=20240000.7=h5888daf_1
-  - dask-core=2024.11.2=pyhff2d567_1
-  - deprecation=2.1.0=pyh9f0ad1d_0
-  - fsspec=2024.10.0=pyhff2d567_0
+  - charset-normalizer=3.4.1=pyhd8ed1ab_0
+  - coin-or-cbc=2.10.12=h8b142ea_1
+  - coin-or-cgl=0.60.9=h1d3f3f2_0
+  - coin-or-clp=1.17.10=h07f2a63_0
+  - coin-or-osi=0.108.11=h6514dde_1
+  - coin-or-utils=2.11.12=h99da652_1
+  - cppad=20250000.2=h5888daf_0
   - gmp=6.3.0=hac33072_2
   - gurobi=12.0.0=py312_0
-  - h2=4.1.0=pyhd8ed1ab_0
-  - hpack=4.0.0=pyh9f0ad1d_0
-  - hyperframe=6.0.1=pyhd8ed1ab_0
-  - idna=3.10=pyhd8ed1ab_0
-  - importlib-metadata=8.5.0=pyha770c72_0
-  - ipopt=3.14.16=h122424a_10
+  - h2=4.2.0=pyhd8ed1ab_0
+  - hpack=4.1.0=pyhd8ed1ab_0
+  - hyperframe=6.1.0=pyhd8ed1ab_0
+  - idna=3.10=pyhd8ed1ab_1
+  - ipopt=3.14.17=h59d4785_0
   - ld_impl_linux-64=2.43=h712a8e2_2
-  - libblas=3.9.0=25_linux64_openblas
-  - libcblas=3.9.0=25_linux64_openblas
-  - libedit=3.1.20191231=he28a2e2_2
+  - libblas=3.9.0=29_h59b9bed_openblas
+  - libcblas=3.9.0=29_he106b2a_openblas
   - libexpat=2.6.4=h5888daf_0
-  - libffi=3.4.2=h7f98852_5
+  - libffi=3.4.6=h2dba641_0
   - libgcc=14.2.0=h77fa898_1
   - libgcc-ng=14.2.0=h69a702a_1
   - libgfortran=14.2.0=h69a702a_1
   - libgfortran-ng=14.2.0=h69a702a_1
   - libgfortran5=14.2.0=hd5240d6_1
-  - libgomp=14.2.0=h77fa898_1
   - libhwloc=2.11.2=default_h0d58e46_1001
   - libiconv=1.17=hd590300_2
-  - liblapack=3.9.0=25_linux64_openblas
+  - liblapack=3.9.0=29_h7ac8fdf_openblas
+  - liblapacke=3.9.0=29_he2f377e_openblas
+  - liblzma=5.6.4=hb9d3cd8_0
+  - liblzma-devel=5.6.4=hb9d3cd8_0
   - libnsl=2.0.1=hd590300_0
   - libopenblas=0.3.28=pthreads_h94d23a6_1
   - libscotch=7.0.4=h2fe6a88_5
   - libspral=2024.05.08=h2b245be_4
-  - libsqlite=3.47.0=hadc24fc_1
+  - libsqlite=3.48.0=hee588c1_1
   - libstdcxx=14.2.0=hc0a3c3a_1
   - libstdcxx-ng=14.2.0=h4852527_1
   - libuuid=2.38.1=h0b41bf4_0
   - libxcrypt=4.4.36=hd590300_1
-  - libxml2=2.13.5=h064dc61_0
+  - libxml2=2.13.5=h0d44e9d_1
   - libzlib=1.3.1=hb9d3cd8_2
-  - linopy=0.4.1=pyhff2d567_0
-  - locket=1.0.0=pyhd8ed1ab_0
+  - llvm-openmp=19.1.7=h024ca30_0
   - metis=5.1.0=hd0bcaf9_1007
+  - mkl=2024.2.2=ha957f24_16
   - mpfr=4.2.1=h90cbb55_3
-  - mumps-include=5.7.3=ha770c72_5
+  - mumps-include=5.7.3=ha770c72_7
   - mumps-seq=5.7.3=h27a6a8b_0
-  - ncurses=6.5=he02047a_1
-  - nomkl=1.0=h5ca1d4c_0
-  - numexpr=2.10.1=py312h6a710ac_103
-  - numpy=1.26.4=py312heda63a1_0
-  - openssl=3.4.0=hb9d3cd8_0
-  - packaging=24.2=pyhff2d567_1
-  - pandas=2.2.3=py312hf9745cd_1
-  - partd=1.4.2=pyhd8ed1ab_0
-  - pip=24.3.1=pyh8b19718_0
-  - polars=1.12.0=py312hfe7c9be_1
-  - pycparser=2.22=pyhd8ed1ab_0
-  - pyscipopt=5.2.1=py312h2ec8cdc_0
-  - pysocks=1.7.1=pyha2e5f31_6
-  - python=3.12.7=hc5c86c4_0_cpython
-  - python-dateutil=2.9.0.post0=pyhff2d567_0
-  - python-tzdata=2024.2=pyhd8ed1ab_0
+  - ncurses=6.5=h2d0b736_3
+  - openssl=3.4.1=h7b32b05_0
+  - pip=25.0.1=pyh8b19718_0
+  - pycparser=2.22=pyh29332c3_1
+  - pyscipopt=5.3.0=py312h2ec8cdc_0
+  - pysocks=1.7.1=pyha55dd90_7
+  - python=3.12.9=h9e4cc4f_0_cpython
   - python_abi=3.12=5_cp312
-  - pytz=2024.1=pyhd8ed1ab_0
-  - pyyaml=6.0.2=py312h66e93f0_1
   - readline=8.2=h8228510_1
-  - requests=2.32.3=pyhd8ed1ab_0
-  - scip=9.1.1=h445098e_3
-  - scipy=1.14.1=py312h62794b6_1
-  - setuptools=75.5.0=pyhff2d567_0
-  - six=1.16.0=pyh6c4a22f_0
-  - tbb=2022.0.0=hceb3a55_0
+  - requests=2.32.3=pyhd8ed1ab_1
+  - scip=9.2.1=h072bc7a_0
+  - setuptools=75.8.0=pyhff2d567_0
+  - tbb=2021.13.0=hceb3a55_1
   - tk=8.6.13=noxft_h4845f30_101
-  - toolz=1.0.0=pyhd8ed1ab_0
-  - tqdm=4.67.0=pyhd8ed1ab_0
-  - tzdata=2024b=hc8b5060_0
-  - unixodbc=2.3.12=h661eb56_0
-  - urllib3=2.2.3=pyhd8ed1ab_0
-  - wheel=0.45.0=pyhd8ed1ab_0
-  - xarray=2024.10.0=pyhd8ed1ab_0
-  - xz=5.2.6=h166bdaf_0
-  - yaml=0.2.5=h7f98852_2
-  - zipp=3.21.0=pyhd8ed1ab_0
+  - urllib3=2.3.0=pyhd8ed1ab_0
+  - wheel=0.45.1=pyhd8ed1ab_1
+  - xz=5.6.4=hbcc6ac9_0
+  - xz-gpl-tools=5.6.4=hbcc6ac9_0
+  - xz-tools=5.6.4=hb9d3cd8_0
   - zlib=1.3.1=hb9d3cd8_2
   - zstandard=0.23.0=py312hef9b889_1
   - zstd=1.5.6=ha6fb4c9_0
   - pip:
-      - highspy==1.8.1
+      - bottleneck==1.4.2
+      - click==8.1.8
+      - cloudpickle==3.1.1
+      - dask==2025.2.0
+      - deprecation==2.1.0
+      - fsspec==2025.2.0
+      - highspy==1.9.0
+      - linopy==0.5.0
+      - locket==1.0.0
+      - numexpr==2.10.2
+      - numpy==1.26.4
+      - packaging==24.2
+      - pandas==2.2.3
+      - partd==1.4.2
+      - polars==1.22.0
+      - python-dateutil==2.9.0.post0
+      - pytz==2025.1
+      - pyyaml==6.0.2
+      - scipy==1.15.1
+      - six==1.17.0
+      - toolz==1.0.0
+      - tqdm==4.67.1
+      - tzdata==2025.1
+      - xarray==2025.1.2
+prefix: /scratch/htc/skrishna/conda/envs/benchmark-2024

--- a/runner/envs/benchmark-2024.yaml
+++ b/runner/envs/benchmark-2024.yaml
@@ -7,12 +7,13 @@ dependencies:
 - python>=3.12
 - pip
 
-- linopy>=0.4.1
 - requests>=2.32
 
-- scip>=9.1
-- pyscipopt>=5.2
-- gurobi>=12
+- coin-or-cbc==2.10.12
+- scip==9.2.1
+- pyscipopt==5.3.0
+- gurobi==12.0.0
 
 - pip:
-  - highspy>=1.8.1
+  - highspy==1.9.0
+  - linopy>=0.5.0

--- a/runner/envs/benchmark-tests-fixed.yaml
+++ b/runner/envs/benchmark-tests-fixed.yaml
@@ -2,105 +2,108 @@ name: benchmark-tests
 channels:
   - conda-forge
   - https://conda.anaconda.org/gurobi
-  - defaults
+  - nodefaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
-  - _openmp_mutex=4.5=2_gnu
-  - ampl-mp=3.1.0=h2cc385e_1006
-  - bottleneck=1.4.2=py312hc0a28a1_0
+  - _openmp_mutex=4.5=2_kmp_llvm
+  - ampl-asl=1.0.0=h5888daf_2
   - brotli-python=1.1.0=py312h2ec8cdc_2
   - bzip2=1.0.8=h4bc722e_7
-  - ca-certificates=2024.8.30=hbcca054_0
-  - certifi=2024.8.30=pyhd8ed1ab_0
+  - ca-certificates=2025.1.31=hbcca054_0
+  - certifi=2025.1.31=pyhd8ed1ab_0
   - cffi=1.17.1=py312h06ac9bb_0
-  - charset-normalizer=3.4.0=pyhd8ed1ab_0
-  - click=8.1.7=unix_pyh707e725_0
-  - cloudpickle=3.1.0=pyhd8ed1ab_1
-  - colorama=0.4.6=pyhd8ed1ab_0
-  - cppad=20240000.7=h5888daf_1
-  - dask-core=2024.11.2=pyhff2d567_1
-  - deprecation=2.1.0=pyh9f0ad1d_0
-  - fsspec=2024.10.0=pyhff2d567_0
+  - charset-normalizer=3.4.1=pyhd8ed1ab_0
+  - coin-or-cbc=2.10.12=h8b142ea_1
+  - coin-or-cgl=0.60.9=h1d3f3f2_0
+  - coin-or-clp=1.17.10=h07f2a63_0
+  - coin-or-osi=0.108.11=h6514dde_1
+  - coin-or-utils=2.11.12=h99da652_1
+  - cppad=20250000.2=h5888daf_0
   - glpk=5.0=h445213a_0
   - gmp=6.3.0=hac33072_2
-  - h2=4.1.0=pyhd8ed1ab_0
-  - hpack=4.0.0=pyh9f0ad1d_0
-  - hyperframe=6.0.1=pyhd8ed1ab_0
-  - idna=3.10=pyhd8ed1ab_0
-  - importlib-metadata=8.5.0=pyha770c72_0
-  - ipopt=3.14.16=h122424a_10
+  - h2=4.2.0=pyhd8ed1ab_0
+  - hpack=4.1.0=pyhd8ed1ab_0
+  - hyperframe=6.1.0=pyhd8ed1ab_0
+  - idna=3.10=pyhd8ed1ab_1
+  - ipopt=3.14.17=h59d4785_0
   - ld_impl_linux-64=2.43=h712a8e2_2
-  - libblas=3.9.0=25_linux64_openblas
-  - libcblas=3.9.0=25_linux64_openblas
-  - libedit=3.1.20191231=he28a2e2_2
+  - libblas=3.9.0=29_h59b9bed_openblas
+  - libcblas=3.9.0=29_he106b2a_openblas
   - libexpat=2.6.4=h5888daf_0
-  - libffi=3.4.2=h7f98852_5
+  - libffi=3.4.6=h2dba641_0
   - libgcc=14.2.0=h77fa898_1
   - libgcc-ng=14.2.0=h69a702a_1
   - libgfortran=14.2.0=h69a702a_1
   - libgfortran-ng=14.2.0=h69a702a_1
   - libgfortran5=14.2.0=hd5240d6_1
-  - libgomp=14.2.0=h77fa898_1
   - libhwloc=2.11.2=default_h0d58e46_1001
   - libiconv=1.17=hd590300_2
-  - liblapack=3.9.0=25_linux64_openblas
+  - liblapack=3.9.0=29_h7ac8fdf_openblas
+  - liblapacke=3.9.0=29_he2f377e_openblas
+  - liblzma=5.6.4=hb9d3cd8_0
+  - liblzma-devel=5.6.4=hb9d3cd8_0
   - libnsl=2.0.1=hd590300_0
   - libopenblas=0.3.28=pthreads_h94d23a6_1
   - libscotch=7.0.4=h2fe6a88_5
   - libspral=2024.05.08=h2b245be_4
-  - libsqlite=3.47.0=hadc24fc_1
+  - libsqlite=3.48.0=hee588c1_1
   - libstdcxx=14.2.0=hc0a3c3a_1
   - libstdcxx-ng=14.2.0=h4852527_1
   - libuuid=2.38.1=h0b41bf4_0
   - libxcrypt=4.4.36=hd590300_1
-  - libxml2=2.13.5=h064dc61_0
+  - libxml2=2.13.5=h0d44e9d_1
   - libzlib=1.3.1=hb9d3cd8_2
-  - linopy=0.4.4=pyhd8ed1ab_0
-  - locket=1.0.0=pyhd8ed1ab_0
+  - llvm-openmp=19.1.7=h024ca30_0
   - metis=5.1.0=hd0bcaf9_1007
+  - mkl=2024.2.2=ha957f24_16
   - mpfr=4.2.1=h90cbb55_3
-  - mumps-include=5.7.3=ha770c72_5
+  - mumps-include=5.7.3=ha770c72_7
   - mumps-seq=5.7.3=h27a6a8b_0
-  - ncurses=6.5=he02047a_1
-  - nomkl=1.0=h5ca1d4c_0
-  - numexpr=2.10.1=py312h6a710ac_103
-  - numpy=1.26.4=py312heda63a1_0
-  - openssl=3.4.0=hb9d3cd8_0
-  - packaging=24.2=pyhff2d567_1
-  - pandas=2.2.3=py312hf9745cd_1
-  - partd=1.4.2=pyhd8ed1ab_0
-  - pip=24.3.1=pyh8b19718_0
-  - polars=1.14.0=py312hfe7c9be_1
-  - pycparser=2.22=pyhd8ed1ab_0
-  - pyscipopt=5.2.1=py312h2ec8cdc_0
-  - pysocks=1.7.1=pyha2e5f31_6
-  - python=3.12.7=hc5c86c4_0_cpython
-  - python-dateutil=2.9.0.post0=pyhff2d567_0
-  - python-tzdata=2024.2=pyhd8ed1ab_0
+  - ncurses=6.5=h2d0b736_3
+  - openssl=3.4.1=h7b32b05_0
+  - pip=25.0.1=pyh8b19718_0
+  - pycparser=2.22=pyh29332c3_1
+  - pyscipopt=5.3.0=py312h2ec8cdc_0
+  - pysocks=1.7.1=pyha55dd90_7
+  - python=3.12.9=h9e4cc4f_0_cpython
   - python_abi=3.12=5_cp312
-  - pytz=2024.1=pyhd8ed1ab_0
-  - pyyaml=6.0.2=py312h66e93f0_1
   - readline=8.2=h8228510_1
-  - requests=2.32.3=pyhd8ed1ab_0
-  - scip=9.1.1=h445098e_3
-  - scipy=1.14.1=py312h62794b6_1
-  - setuptools=75.6.0=pyhff2d567_0
-  - six=1.16.0=pyh6c4a22f_0
-  - tbb=2022.0.0=hceb3a55_0
+  - requests=2.32.3=pyhd8ed1ab_1
+  - scip=9.2.1=h072bc7a_0
+  - setuptools=75.8.0=pyhff2d567_0
+  - tbb=2021.13.0=hceb3a55_1
   - tk=8.6.13=noxft_h4845f30_101
-  - toolz=1.0.0=pyhd8ed1ab_0
-  - tqdm=4.67.1=pyhd8ed1ab_0
-  - tzdata=2024b=hc8b5060_0
-  - unixodbc=2.3.12=h661eb56_0
-  - urllib3=2.2.3=pyhd8ed1ab_0
-  - wheel=0.45.1=pyhd8ed1ab_0
-  - xarray=2024.11.0=pyhd8ed1ab_0
-  - xz=5.2.6=h166bdaf_0
-  - yaml=0.2.5=h7f98852_2
-  - zipp=3.21.0=pyhd8ed1ab_0
+  - urllib3=2.3.0=pyhd8ed1ab_0
+  - wheel=0.45.1=pyhd8ed1ab_1
+  - xz=5.6.4=hbcc6ac9_0
+  - xz-gpl-tools=5.6.4=hbcc6ac9_0
+  - xz-tools=5.6.4=hb9d3cd8_0
   - zlib=1.3.1=hb9d3cd8_2
   - zstandard=0.23.0=py312hef9b889_1
   - zstd=1.5.6=ha6fb4c9_0
   - pip:
-      - highspy==1.8.1
+      - bottleneck==1.4.2
+      - click==8.1.8
+      - cloudpickle==3.1.1
+      - dask==2025.2.0
+      - deprecation==2.1.0
+      - fsspec==2025.2.0
+      - highspy==1.9.0
+      - linopy==0.5.0
+      - locket==1.0.0
+      - numexpr==2.10.2
+      - numpy==1.26.4
+      - packaging==24.2
+      - pandas==2.2.3
+      - partd==1.4.2
+      - polars==1.22.0
+      - python-dateutil==2.9.0.post0
+      - pytz==2025.1
+      - pyyaml==6.0.2
+      - scipy==1.15.1
+      - six==1.17.0
+      - toolz==1.0.0
+      - tqdm==4.67.1
+      - tzdata==2025.1
+      - xarray==2025.1.2
 prefix: /scratch/htc/skrishna/conda/envs/benchmark-tests

--- a/runner/envs/benchmark-tests.yaml
+++ b/runner/envs/benchmark-tests.yaml
@@ -7,12 +7,13 @@ dependencies:
 - python>=3.12
 - pip
 
-- linopy>=0.4.1
 - requests>=2.32
 
-- scip>=9.1
-- pyscipopt>=5.2
+- coin-or-cbc==2.10.12
+- scip==9.2.1
+- pyscipopt==5.3.0
 - glpk==5.0.0
 
 - pip:
-  - highspy>=1.8.1
+  - highspy==1.9.0
+  - linopy>=0.5.0

--- a/runner/run_benchmarks.py
+++ b/runner/run_benchmarks.py
@@ -15,7 +15,7 @@ import yaml
 def get_conda_package_versions(solvers, env_name=None):
     try:
         # Base command
-        cmd = ["conda", "list"]
+        cmd = ["/opt/conda/bin/conda", "list"]
 
         # Add environment name if provided
         if env_name:
@@ -35,10 +35,11 @@ def get_conda_package_versions(solvers, env_name=None):
             if len(parts) >= 2:  # Ensure package name and version are present
                 installed_packages[parts[0]] = parts[1]
 
+        # Map solver names to their conda package names
+        name_to_pkg = {"highs": "highspy", "cbc": "coin-or-cbc"}
         solver_versions = {}
         for solver in solvers:
-            # HiGHS is called highspy, so map that accordingly
-            package = "highspy" if solver == "highs" else solver
+            package = name_to_pkg.get(solver, solver)
             solver_versions[solver] = installed_packages.get(package, None)
 
         return solver_versions
@@ -366,7 +367,7 @@ if __name__ == "__main__":
     override = sys.argv[3].lower() == "true" if len(sys.argv) > 3 else True
 
     # solvers = ["highs", "glpk"]  # For dev and testing
-    solvers = ["highs", "glpk", "scip"]  # For production
+    solvers = ["cbc", "highs", "glpk", "scip"]  # For production
 
     main(benchmark_yaml_path, solvers, year, override=override)
     # Print a message indicating completion

--- a/runner/run_benchmarks.py
+++ b/runner/run_benchmarks.py
@@ -14,12 +14,11 @@ import yaml
 
 def get_conda_package_versions(solvers, env_name=None):
     try:
-        # Base command
-        cmd = ["/opt/conda/bin/conda", "list"]
-
-        # Add environment name if provided
+        # List packages in the conda environment
+        cmd = "conda list"
         if env_name:
-            cmd.extend(["-n", env_name])
+            cmd += " -n " + env_name
+        cmd = ["bash", "-i", "-c", cmd]
 
         # Run the conda list command
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)

--- a/runner/run_solver.py
+++ b/runner/run_solver.py
@@ -23,6 +23,7 @@ def get_solver(solver_name):
         "scip": {
             "randomization/randomseedshift": 0,
         },
+        "cbc": {"randomCbcSeed": 1},  # 0 indicates time of day
     }
 
     if solver_name.lower() in seed_options:
@@ -44,8 +45,10 @@ def is_mip_problem(solver_model, solver_name):
     elif solver_name == "highs":
         info = solver_model.getInfo()
         return info.mip_node_count >= 0
-    elif solver_name == "glpk":
-        # GLPK does not provide a solver model in the solver result, so MIP problem detection is not possible.
+    elif solver_name in {"glpk", "cbc"}:
+        # These solvers do not provide a solver model in the solver result,
+        # so MIP problem detection is not possible.
+        # TODO preprocess benchmarks and add this info to metadata
         return False
     else:
         raise NotImplementedError(f"The solver '{solver_name}' is not supported.")
@@ -71,8 +74,8 @@ def get_duality_gap(solver_model, solver_name: str):
     elif solver_name == "highs" and solver_model:
         info = solver_model.getInfo()
         return info.mip_gap if hasattr(info, "mip_gap") else None
-    elif solver_name == "glpk" and solver_model:
-        # GLPK does not provide a solver model in solver_result, so we cannot calculate the mip_gap.
+    elif solver_name in {"glpk", "cbc"}:
+        # TODO is there another way to obtain duality gap when there's no solver_model?
         return None
     else:
         raise NotImplementedError(f"The solver '{solver_name}' is not supported.")


### PR DESCRIPTION
Adds CBC solver as per #88 
Uses the new version of linopy that has https://github.com/PyPSA/linopy/pull/410 so this closes https://github.com/open-energy-transition/solver-benchmark/issues/68