### PR TITLE
feat: use all available options from the metadata file, quick fixes, …

### DIFF
--- a/website-nextjs/src/components/admin/BenchmarksSection.tsx
+++ b/website-nextjs/src/components/admin/BenchmarksSection.tsx
@@ -2,11 +2,11 @@ import { useSelector } from "react-redux"
 
 import { CircleIcon, CloseIcon } from "@/assets/icons"
 import D3Chart from "../shared/D3PlotChart"
-import { ResultState } from "@/redux/results/reducer"
+import { IResultState } from "@/types/state"
 
 const BenchmarksSection = () => {
   const benchmarkResults = useSelector(
-    (state: { results: ResultState }) => {
+    (state: { results: IResultState }) => {
       return state.results.benchmarkLatestResults
     }
   )

--- a/website-nextjs/src/components/admin/DetailSection.tsx
+++ b/website-nextjs/src/components/admin/DetailSection.tsx
@@ -7,21 +7,21 @@ import {
   LayoutGroupIcon,
   VectorSquareIcon,
 } from "@/assets/icons"
-import { ResultState } from "@/redux/results/reducer"
 import { useMemo } from "react"
+import { IResultState } from "@/types/state"
 
 const DetailSection = () => {
-  const benchmarkResults = useSelector(
-    (state: { results: ResultState }) => {
-      return state.results.benchmarkResults
-    }
-  )
-
-  const availableBenchmarks = useSelector((state: { results: ResultState }) => {
-    return state.results.availableBenchmarks
+  const benchmarkResults = useSelector((state: { results: IResultState }) => {
+    return state.results.rawBenchmarkResults
   })
 
-  const availableSolves = useSelector((state: { results: ResultState }) => {
+  const rawMetaData = useSelector((state: { results: IResultState }) => {
+    return state.results.rawMetaData
+  })
+
+  const availableBenchmarksCount = Object.keys(rawMetaData).length
+
+  const availableSolves = useSelector((state: { results: IResultState }) => {
     return state.results.availableSolves
   })
 
@@ -48,8 +48,15 @@ const DetailSection = () => {
       label: "Solvers",
       value: availableSolves.length,
       icon: <VectorSquareIcon />,
-      generateLabel: () =>
-        `Solvers: ${availableSolves.length} (${avaliableVersion.length} versions)`,
+      generateLabel: () => (
+        <>
+          Solvers:{" "}
+          <span className="font-bold">
+            {availableSolves.length} {`(${avaliableVersion.length}`} versions
+            {")"}
+          </span>
+        </>
+      ),
     },
     {
       label: "Iteration",
@@ -58,10 +65,17 @@ const DetailSection = () => {
     },
     {
       label: "Benchmarks",
-      value: availableBenchmarks.length,
+      value: availableBenchmarksCount,
       icon: <GraphBarIcon />,
-      generateLabel: () =>
-        `Benchmarks: ${availableBenchmarks.length} (${avaliableInstance.length} instances)`,
+      generateLabel: () => (
+        <>
+          Benchmarks:{" "}
+          <span className="font-bold">
+            {availableBenchmarksCount} {`(${avaliableInstance.length}`} instances
+            {")"}
+          </span>
+        </>
+      ),
     },
     {
       label: "Memory",
@@ -70,7 +84,7 @@ const DetailSection = () => {
     },
     {
       label: "Timeout",
-      value: "15 min",
+      value: "10 min",
       icon: <DatabaseIcon />,
     },
     {

--- a/website-nextjs/src/components/admin/FilterSection.tsx
+++ b/website-nextjs/src/components/admin/FilterSection.tsx
@@ -5,22 +5,36 @@ import {
   WrenchIcon,
 } from "@/assets/icons"
 import { useSelector, useDispatch } from "react-redux"
-import {
-  Sector,
-  Technique,
-  KindOfProblem,
-  Model,
-  ProblemSize,
-} from "@/constants"
 import filterAction from "@/redux/filters/actions"
-import { FilterState } from "@/redux/filters/reducer"
+import Popup from "reactjs-popup"
+import { IFilterState, IResultState } from "@/types/state"
 
 const FilterSection = () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const dispatch = useDispatch<any>()
 
   const selectedFilters = useSelector(
-    (state: { filters: FilterState }) => state.filters
+    (state: { filters: IFilterState }) => state.filters
+  )
+
+  const availableSectors = useSelector(
+    (state: { results: IResultState }) => state.results.availableSectors
+  )
+
+  const availableTechniques = useSelector(
+    (state: { results: IResultState }) => state.results.availableTechniques
+  )
+
+  const availableKindOfProblems = useSelector(
+    (state: { results: IResultState }) => state.results.availableKindOfProblems
+  )
+
+  const availableModels = useSelector(
+    (state: { results: IResultState }) => state.results.availableModels
+  )
+
+  const availableProblemSizes = useSelector(
+    (state: { results: IResultState }) => state.results.availableProblemSizes
   )
 
   const handleCheckboxChange = ({
@@ -37,53 +51,17 @@ const FilterSection = () => {
     )
   }
 
-  const getLabel = (type: string, value: string) => {
-    switch (type) {
-      case "sectors":
-        switch (value) {
-          case Sector.SectorCoupled:
-            return "Sector coupled"
-
-          case Sector.UpstreamElectricTransportCommercialResidentialIndustrial:
-            return "Upstream..."
-
-          default:
-            return value
-        }
-      case "model":
-        switch (value) {
-          case Model.GenX:
-            return "Gen X"
-          case Model.PowerModel:
-            return "Power Model"
-          case Model.PyPSAEur:
-            return "PyPSA - Eur"
-          default:
-            return value
-        }
-      case "kindOfProblem":
-        switch (value) {
-          case KindOfProblem.SteadyStateOptimalPowerFlow:
-            return "Steady-state power flow "
-          default:
-            return value
-        }
-      default:
-        throw Error("Invalid value")
-    }
-  }
-
   return (
     <div className="bg-white rounded-xl my-2">
       <div className="flex text-dark-grey">
         {/* Sectors */}
         <div className="text-xs border-r border-stroke">
-          <div className="flex items-center border-b border-stroke px-3 py-2 gap-1 pr-6">
+          <div className="flex items-center border-b border-stroke px-3 py-2 gap-1 pr-6 sticky">
             <BrightIcon className="w-5 h-5" />
             <span>Sectors</span>
           </div>
           <div className="text-xs">
-            {Object.values(Sector).map((sector) => (
+            {availableSectors.map((sector) => (
               <div
                 className="flex items-center gap-1 p-3 relative group"
                 key={sector}
@@ -106,9 +84,17 @@ const FilterSection = () => {
                       value: sector,
                     })
                   }
-                  className="w-max cursor-pointer max-w-[30px]"
+                  className="w-max cursor-pointer max-w-[50px] text-ellipsis whitespace-nowrap overflow-hidden"
                 >
-                  {getLabel("sectors", sector)}
+                  <Popup
+                    on={["hover"]}
+                    trigger={() => <span>{sector}</span>}
+                    position="top right"
+                    closeOnDocumentClick
+                    arrowStyle={{ color: "#ebeff2" }}
+                  >
+                    <div className="bg-stroke p-2 rounded">{sector}</div>
+                  </Popup>
                 </span>
 
                 <span
@@ -134,7 +120,7 @@ const FilterSection = () => {
             <span>Technique</span>
           </div>
           <div className="text-xs">
-            {Object.values(Technique).map((technique) => (
+            {availableTechniques.map((technique) => (
               <div
                 className="flex items-center gap-1 p-3 relative group"
                 key={technique}
@@ -159,7 +145,15 @@ const FilterSection = () => {
                   }
                   className="w-max cursor-pointer"
                 >
-                  {technique}
+                  <Popup
+                    on={["hover"]}
+                    trigger={() => <span>{technique}</span>}
+                    position="top right"
+                    closeOnDocumentClick
+                    arrowStyle={{ color: "#ebeff2" }}
+                  >
+                    <div className="bg-stroke p-2 rounded">{technique}</div>
+                  </Popup>
                 </span>
                 <span
                   className="text-navy hidden group-hover:inline-block ml-0.5 cursor-pointer"
@@ -185,7 +179,7 @@ const FilterSection = () => {
             <span>Kind of Problem</span>
           </div>
           <div className="grid grid-cols-[max-content_max-content] gap-x-1 text-xs">
-            {Object.values(KindOfProblem).map((problem) => (
+            {availableKindOfProblems.map((problem) => (
               <div
                 className="flex items-center gap-1 p-3 relative group"
                 key={problem}
@@ -210,7 +204,15 @@ const FilterSection = () => {
                   }
                   className="w-max cursor-pointer"
                 >
-                  {getLabel("kindOfProblem", problem)}
+                  <Popup
+                    on={["hover"]}
+                    trigger={() => <span>{problem}</span>}
+                    position="top right"
+                    closeOnDocumentClick
+                    arrowStyle={{ color: "#ebeff2" }}
+                  >
+                    <div className="bg-stroke p-2 rounded">{problem}</div>
+                  </Popup>
                 </span>
                 <span
                   className="text-navy hidden group-hover:inline-block ml-0.5 cursor-pointer"
@@ -229,13 +231,13 @@ const FilterSection = () => {
           </div>
         </div>
         {/* Problem Size */}
-        <div className="text-xs border-r border-stroke  w-[60%]">
+        <div className="text-xs border-r border-stroke  w-[40%]">
           <div className="flex items-center border-b border-stroke px-3 py-2 gap-1">
             <WrenchIcon className="w-5 h-5" />
             <span>Problem Size</span>
           </div>
-          <div className="grid grid-cols-3 gap-x-1 text-xs">
-            {Object.values(ProblemSize).map((size) => (
+          <div className="grid grid-cols-2 gap-x-1 text-xs">
+            {availableProblemSizes.map((size) => (
               <div
                 className="flex items-center gap-1 p-3 relative group"
                 key={size}
@@ -285,7 +287,7 @@ const FilterSection = () => {
             <span>Model</span>
           </div>
           <div className="grid grid-cols-3 gap-x-2 text-xs">
-            {Object.values(Model).map((model) => (
+            {availableModels.map((model) => (
               <div
                 className="flex items-center gap-1 p-3 relative group"
                 key={model}
@@ -310,7 +312,15 @@ const FilterSection = () => {
                   }
                   className="w-max cursor-pointer"
                 >
-                  {getLabel("model", model)}
+                  <Popup
+                    on={["hover"]}
+                    trigger={() => <span>{model}</span>}
+                    position="top right"
+                    closeOnDocumentClick
+                    arrowStyle={{ color: "#ebeff2" }}
+                  >
+                    <div className="bg-stroke p-2 rounded">{model}</div>
+                  </Popup>
                 </span>
                 <span
                   className="text-navy hidden group-hover:inline-block ml-0.5 cursor-pointer"

--- a/website-nextjs/src/components/admin/ResultsSections.tsx
+++ b/website-nextjs/src/components/admin/ResultsSections.tsx
@@ -5,9 +5,9 @@ import { getHighestVersion } from "@/utils/versions"
 import { calculateSgm } from "@/utils/calculations"
 import { roundNumber } from "@/utils/number"
 import { MaxMemoryUsage, MaxRunTime } from "@/constants"
-import { ResultState } from "@/redux/results/reducer"
 import Popup from "reactjs-popup"
 import { getLatestBenchmarkResult } from "@/utils/results"
+import { IResultState } from "@/types/state"
 
 const ResultsSection = () => {
   const columns = [
@@ -76,13 +76,15 @@ const ResultsSection = () => {
     },
   ]
 
-  const benchmarkResults = useSelector((state: { results: ResultState }) => {
+  const benchmarkResults = useSelector((state: { results: IResultState }) => {
     return state.results.benchmarkLatestResults
   })
 
-  const rawBenchmarkResults = useSelector((state: { results: ResultState }) => {
-    return state.results.rawBenchmarkResults
-  })
+  const rawBenchmarkResults = useSelector(
+    (state: { results: IResultState }) => {
+      return state.results.rawBenchmarkResults
+    }
+  )
 
   const latestBenchmarkResult = getLatestBenchmarkResult(rawBenchmarkResults)
 
@@ -211,7 +213,7 @@ const ResultsSection = () => {
     uniqueBenchmarkCount: number
   ) => {
     const numberSolvedBenchmark = getNumberSolvedBenchmark(solver)
-    const percentage = numberSolvedBenchmark * 100 / uniqueBenchmarkCount
+    const percentage = (numberSolvedBenchmark * 100) / uniqueBenchmarkCount
     return `${roundNumber(
       percentage,
       1
@@ -288,8 +290,6 @@ const ResultsSection = () => {
 
   const [activedIndex, setActivedIndex] = useState(0)
 
-  if (!benchmarkResults.length) return <></>
-
   return (
     <div>
       <div className="pb-3 pl-3">
@@ -302,12 +302,13 @@ const ResultsSection = () => {
             </span>
           )}
         </div>
-        <div className="text-dark-grey text-sm flex items-center">
-          You can rank the latest version of each solver by number of solved benchmark instances, or by the normalized shifted geometric mean (SGM
-          <div className="flex gap-2">
+        <div className="text-dark-grey text-sm flex flex-wrap items-center">
+          You can rank the latest version of each solver by number of solved
+          benchmark instances, or by the normalized shifted geometric mean (SGM{" "}
+          <span className="inline-flex gap-2">
             <Popup
               on={["hover"]}
-              trigger={() => <QuestionLine className="w-4 h-4" />}
+              trigger={() => <span className="flex items-center"><QuestionLine className="w-4 h-4" />)</span>}
               position="right center"
               closeOnDocumentClick
               arrowStyle={{ color: "#ebeff2" }}
@@ -320,11 +321,12 @@ const ResultsSection = () => {
                   SGM = exp(sum{"{i in 1..n}"} ln(max(1, v[i] + sh)) / n) - sh
                 </span>
                 <br />
-                We use sh = 10, and then we normalize the means by dividing them by the smallest mean.
+                We use sh = 10, and then we normalize the means by dividing them
+                by the smallest mean.
               </div>
             </Popup>
-          </div>
-          ) of runtime and memory consumption over all benchmarks
+          </span>
+          of runtime and memory consumption over all benchmarks
         </div>
       </div>
       <div className="flex text-xs leading-1.5">
@@ -364,7 +366,7 @@ const ResultsSection = () => {
                 }`}
                 onClick={() => setActivedIndex(index)}
               >
-                {item[column.field as keyof (typeof tableData)[0]]}
+                {item[column.field as keyof (typeof tableData)[0]] ?? '-'}
               </div>
             ))}
           </div>

--- a/website-nextjs/src/components/admin/benchmark-detail/BenchmarkTableResult.tsx
+++ b/website-nextjs/src/components/admin/benchmark-detail/BenchmarkTableResult.tsx
@@ -17,20 +17,19 @@ import {
 import { BenchmarkResult } from "@/types/benchmark"
 import Popup from "reactjs-popup"
 import { Color } from "@/constants/color"
-import { ResultState } from "@/redux/results/reducer"
-import { MetaData, MetaDataEntry, Size } from "@/types/meta-data"
-import { KindOfProblem, Model, Sector, Technique } from "@/constants"
+import { MetaDataEntry } from "@/types/meta-data"
 import Link from "next/link"
 import { PATH_DASHBOARD } from "@/constants/path"
 import { ArrowIcon, ArrowRightIcon, SortVerticalIcon } from "@/assets/icons"
 import PaginationTable from "@/components/shared/tables/PaginationTable"
+import { IResultState } from "@/types/state"
 
 interface IColumnTable extends MetaDataEntry {
   name: string
 }
 
 const BenchmarkTableResult = () => {
-  const metaData = useSelector((state: { results: ResultState }) => {
+  const metaData = useSelector((state: { results: IResultState }) => {
     return state.results.metaData
   })
 

--- a/website-nextjs/src/components/admin/benchmark-detail/BenchmarksSection.tsx
+++ b/website-nextjs/src/components/admin/benchmark-detail/BenchmarksSection.tsx
@@ -3,11 +3,11 @@ import { useSelector } from "react-redux"
 
 import { CircleIcon, CloseIcon } from "@/assets/icons"
 import D3Chart from "@/components/shared/D3PlotChart"
-import { ResultState } from "@/redux/results/reducer"
+import { IResultState } from "@/types/state"
 
 const BenchmarksSection = ({ benchmarkName }: { benchmarkName: string }) => {
   const benchmarkResults = useSelector(
-    (state: { results: ResultState }) => {
+    (state: { results: IResultState }) => {
       return state.results.benchmarkLatestResults
     }
   )

--- a/website-nextjs/src/components/admin/benchmark-detail/InstancesTableResult.tsx
+++ b/website-nextjs/src/components/admin/benchmark-detail/InstancesTableResult.tsx
@@ -9,11 +9,9 @@ import {
   getCoreRowModel,
   getFilteredRowModel,
   getSortedRowModel,
-  getPaginationRowModel,
   getFacetedUniqueValues,
   useReactTable,
 } from "@tanstack/react-table"
-import { ResultState } from "@/redux/results/reducer"
 import { getInstance } from "@/utils/meta-data"
 import { MetaDataEntry } from "@/types/meta-data"
 

--- a/website-nextjs/src/components/admin/benchmark-detail/MilpTableResult.tsx
+++ b/website-nextjs/src/components/admin/benchmark-detail/MilpTableResult.tsx
@@ -13,9 +13,7 @@ import {
   getFacetedUniqueValues,
   useReactTable,
 } from "@tanstack/react-table"
-import { ResultState } from "@/redux/results/reducer"
-import { getInstance } from "@/utils/meta-data"
-import { MetaDataEntry } from "@/types/meta-data"
+import { IResultState } from "@/types/state"
 
 const MilpTableResult = ({ benchmarkName }: { benchmarkName: string }) => {
   const columns = useMemo<
@@ -52,7 +50,7 @@ const MilpTableResult = ({ benchmarkName }: { benchmarkName: string }) => {
     []
   )
 
-  const benchmarkResults = useSelector((state: { results: ResultState }) => {
+  const benchmarkResults = useSelector((state: { results: IResultState }) => {
     return state.results.benchmarkLatestResults
   })
 
@@ -87,7 +85,6 @@ const MilpTableResult = ({ benchmarkName }: { benchmarkName: string }) => {
     getFacetedUniqueValues: getFacetedUniqueValues(),
     manualPagination: false,
   })
-  console.log(table.getPrePaginationRowModel().rows.length)
 
   useEffect(() => {
     table.setPageSize(table.getPrePaginationRowModel().rows.length)

--- a/website-nextjs/src/components/admin/compare-solvers/SolverSelection.tsx
+++ b/website-nextjs/src/components/admin/compare-solvers/SolverSelection.tsx
@@ -1,14 +1,14 @@
-import { ResultState } from "@/redux/results/reducer"
 import { getSolverLabel } from "@/utils/solvers"
 import { useEffect, useState } from "react"
 import { useSelector } from "react-redux"
 import ChartCompare from "./ChartCompare"
+import { IResultState } from "@/types/state"
 
 const SolverSelection = () => {
-  const solversData = useSelector((state: { results: ResultState }) => {
+  const solversData = useSelector((state: { results: IResultState }) => {
     return state.results.solversData
   })
-  const benchmarkResults = useSelector((state: { results: ResultState }) => {
+  const benchmarkResults = useSelector((state: { results: IResultState }) => {
     return state.results.benchmarkResults
   })
 

--- a/website-nextjs/src/components/admin/raw-result/TableResult.tsx
+++ b/website-nextjs/src/components/admin/raw-result/TableResult.tsx
@@ -21,14 +21,14 @@ import { ArrowToRightIcon } from "@/assets/icons"
 import FilterTable from "@/components/shared/tables/FilterTable"
 import PaginationTable from "@/components/shared/tables/PaginationTable"
 import DownloadButton from "@/components/shared/buttons/DownloadButton"
-import { ResultState } from "@/redux/results/reducer"
+import { IResultState } from "@/types/state"
 
 const CSV_URL =
   "https://raw.githubusercontent.com/open-energy-transition/solver-benchmark/main/results/benchmark_results.csv"
 
 const TableResult = () => {
   const benchmarkResults = useSelector(
-    (state: { results: ResultState}) => {
+    (state: { results: IResultState}) => {
       return state.results.benchmarkResults
     }
   )

--- a/website-nextjs/src/components/landing-page/sections/GetStartedSection.tsx
+++ b/website-nextjs/src/components/landing-page/sections/GetStartedSection.tsx
@@ -1,11 +1,11 @@
 import { useSelector } from "react-redux"
 
 import { ArrowUpIcon } from "@/assets/icons"
-import { ResultState } from "@/redux/results/reducer"
 import { useMemo } from "react"
+import { IResultState } from "@/types/state"
 
 const GetStarted = () => {
-  const rawMetaData = useSelector((state: { results: ResultState }) => {
+  const rawMetaData = useSelector((state: { results: IResultState }) => {
     return state.results.rawMetaData
   })
 
@@ -21,12 +21,12 @@ const GetStarted = () => {
     [rawMetaData]
   )
 
-  const availableSolves = useSelector((state: { results: ResultState }) => {
+  const availableSolves = useSelector((state: { results: IResultState }) => {
     return state.results.availableSolves
   })
 
   const availableBenchmarksAndSizes = useSelector(
-    (state: { results: ResultState }) => {
+    (state: { results: IResultState }) => {
       return state.results.availableBenchmarksAndSizes
     }
   )

--- a/website-nextjs/src/constants/index.ts
+++ b/website-nextjs/src/constants/index.ts
@@ -1,21 +1,3 @@
-export enum Sector {
-  Power = "Power",
-  SectorCoupled = "Sector-coupled",
-  UpstreamElectricTransportCommercialResidentialIndustrial = "Upstream, Electric, Transport, Commercial, Residential, Industrial",
-}
-
-export enum Technique {
-  MILP = "MILP",
-  LP = "LP",
-}
-
-export enum KindOfProblem {
-  Infrastructure = "Infrastructure",
-  Operational = "Operational",
-  DCOptimalPowerFlow = "DC optimal power flow",
-  SteadyStateOptimalPowerFlow = "Steady-state optimal power flow",
-}
-
 export enum ProblemSize {
   XXS = "xxs",
   XS = "xs",
@@ -24,16 +6,11 @@ export enum ProblemSize {
   S = "s",
 }
 
-export enum Model {
-  PyPSA = "PyPSA",
-  PyPSAEur = "PyPSA-Eur",
-  Tulipa = "Tulipa",
-  PowerModel = "PowerModels",
-  Sienna = "Sienna",
-  GenX = "GenX",
-  TEMOA = "TEMOA",
-}
-
 export const MaxRunTime = 600
 
 export const MaxMemoryUsage = 8192
+
+export enum Technique {
+  MILP = "MILP",
+  LP = "LP",
+}

--- a/website-nextjs/src/pages/_app.tsx
+++ b/website-nextjs/src/pages/_app.tsx
@@ -8,11 +8,18 @@ import { Provider, useDispatch } from "react-redux"
 import { fontClasses } from "@/styles/fonts"
 import { wrapper } from "@/redux/store"
 import resultActions from "@/redux/results/actions"
+import filterActions from "@/redux/filters/actions"
 import AdminLayout from "@/pages/AdminLayout"
-import { getBenchmarkResults, getLatestBenchmarkResult } from "@/utils/results"
+import {
+  getBenchmarkResults,
+  getLatestBenchmarkResult,
+  getProblemSize,
+} from "@/utils/results"
 import { getMetaData } from "@/utils/meta-data"
 import { BenchmarkResult } from "@/types/benchmark"
-import { MetaData } from "@/types/meta-data"
+import { getHighestVersion } from "@/utils/versions"
+import { ProblemSize } from "@/constants"
+import { IFilterState } from "@/types/state"
 
 function App({ Component, pageProps }: AppProps) {
   const dispatch = useDispatch()
@@ -23,16 +30,86 @@ function App({ Component, pageProps }: AppProps) {
     const initializeData = async () => {
       const results = await getBenchmarkResults()
       const metaData = await getMetaData()
-      dispatch(resultActions.setMetaData(metaData as MetaData))
+
+      const latestHighVersion = getHighestVersion(
+        Array.from(
+          new Set(
+            results
+              .filter((result) => result.solver === "highs")
+              .map((result) => result.solverVersion)
+          )
+        )
+      )
+
+      const problemSizeResult: { [key: string]: ProblemSize } = {}
+      results
+        .filter(
+          (result: BenchmarkResult) =>
+            result.solver === "highs" &&
+            result.solverVersion === latestHighVersion
+        )
+        .forEach((result: BenchmarkResult) => {
+          problemSizeResult[`${result.benchmark}'-'${result.size}`] =
+            getProblemSize(result.runtime)
+        })
+
+      const uniqueValues = {
+        sectors: new Set<string>(),
+        techniques: new Set<string>(),
+        kindOfProblems: new Set<string>(),
+        models: new Set<string>(),
+      }
+
+      Object.keys(metaData).forEach((key) => {
+        const { sectors, technique, kindOfProblem, modelName } = metaData[key]
+        uniqueValues.sectors.add(sectors)
+        uniqueValues.techniques.add(technique)
+        uniqueValues.kindOfProblems.add(kindOfProblem)
+        uniqueValues.models.add(modelName)
+      })
+
+      const availableSectors = Array.from(uniqueValues.sectors)
+      const availableTechniques = Array.from(uniqueValues.techniques)
+      const availableKindOfProblems = Array.from(uniqueValues.kindOfProblems)
+      const availableModels = Array.from(uniqueValues.models)
+      const availableProblemSizes = Array.from(
+        new Set(
+          Object.keys(problemSizeResult).map((key) => problemSizeResult[key])
+        )
+      )
+
+      dispatch(resultActions.setMetaData(metaData))
       dispatch(resultActions.setBenchmarkResults(results as BenchmarkResult[]))
       dispatch(
         resultActions.setBenchmarkLatestResults(
           getLatestBenchmarkResult(results as BenchmarkResult[])
         )
       )
-      dispatch(resultActions.setRawMetaData(metaData as MetaData))
+
+      dispatch(
+        resultActions.setRawMetaData(metaData)
+      )
+      dispatch(
+        resultActions.setAvailableFilterData({
+          availableSectors,
+          availableTechniques,
+          availableKindOfProblems,
+          availableModels,
+          availableProblemSizes,
+        })
+      )
       dispatch(
         resultActions.setRawBenchmarkResults(results as BenchmarkResult[])
+      )
+
+      dispatch(
+        filterActions.setFilter({
+          sectors: availableSectors,
+          technique: availableTechniques,
+          kindOfProblem: availableKindOfProblems,
+          modelName: availableModels,
+          problemSize: availableProblemSizes,
+        } as IFilterState)
       )
     }
 
@@ -42,7 +119,9 @@ function App({ Component, pageProps }: AppProps) {
   const renderLayout = () => {
     return (
       <AdminLayout>
-        <main className={`${fontClasses} bg-light-blue overflow-auto h-[calc(100vh-var(--banner-height))]`}>
+        <main
+          className={`${fontClasses} bg-light-blue overflow-auto h-[calc(100vh-var(--banner-height))]`}
+        >
           <Component {...props} />
         </main>
       </AdminLayout>

--- a/website-nextjs/src/pages/dashboard/benchmark-details/[slug].tsx
+++ b/website-nextjs/src/pages/dashboard/benchmark-details/[slug].tsx
@@ -10,7 +10,6 @@ import {
   ArrowUpIcon,
   HomeIcon,
 } from "@/assets/icons"
-import { ResultState } from "@/redux/results/reducer"
 import { useMemo } from "react"
 import Popup from "reactjs-popup"
 import { Color } from "@/constants/color"
@@ -20,6 +19,7 @@ import Link from "next/link"
 import { PATH_DASHBOARD } from "@/constants/path"
 import MilpTableResult from "@/components/admin/benchmark-detail/MilpTableResult"
 import { Technique } from "@/constants"
+import { IResultState } from "@/types/state"
 
 const PageBenchmarkDetail = () => {
   const isNavExpanded = useSelector(
@@ -29,7 +29,7 @@ const PageBenchmarkDetail = () => {
 
   const benchmarkName = router.query.slug
 
-  const metaData = useSelector((state: { results: ResultState }) => {
+  const metaData = useSelector((state: { results: IResultState }) => {
     return state.results.metaData
   })
 
@@ -75,7 +75,6 @@ const PageBenchmarkDetail = () => {
       value: benchmarkDetail?.milpFeatures,
     },
   ]
-  console.log(benchmarkDetail)
 
   return (
     <>

--- a/website-nextjs/src/pages/dashboard/compare-solvers.tsx
+++ b/website-nextjs/src/pages/dashboard/compare-solvers.tsx
@@ -5,18 +5,18 @@ import { AdminHeader, Footer, Navbar } from "@/components/shared"
 import SolverSelection from "@/components/admin/compare-solvers/SolverSelection"
 import Head from "next/head"
 import FilterSection from "@/components/admin/FilterSection"
-import { ResultState } from "@/redux/results/reducer"
 import { NoSolverPage } from "@/components/admin/compare-solvers/NoSolverPage"
 import { ArrowIcon, HomeIcon } from "@/assets/icons"
 import Link from "next/link"
 import { PATH_DASHBOARD } from "@/constants/path"
+import { IResultState } from "@/types/state"
 
 const PageCompareSolvers = () => {
   const isNavExpanded = useSelector(
     (state: { theme: { isNavExpanded: boolean } }) => state.theme.isNavExpanded
   )
 
-  const solversData = useSelector((state: { results: ResultState }) => {
+  const solversData = useSelector((state: { results: IResultState }) => {
     return state.results.solversData
   })
 

--- a/website-nextjs/src/redux/filters/reducer.ts
+++ b/website-nextjs/src/redux/filters/reducer.ts
@@ -1,60 +1,35 @@
 import { AnyAction } from "redux"
-import { Sector, Technique, KindOfProblem, Model, ProblemSize } from "@/constants"
 
 import actions from "./actions"
+import { IFilterState } from "@/types/state"
 
-const { TOGGLE_FILTER } = actions
+const { TOGGLE_FILTER, SET_FILTER } = actions
 
-export type FilterState = {
-  sectors: Sector[]
-  technique: Technique[]
-  kindOfProblem: KindOfProblem[]
-  problemSize: ProblemSize[]
-  modelName: Model[]
-  benchmarks: string[]
-  solvers: string[]
-  statuses: string[]
-}
-
-const initialState: FilterState = {
-  sectors: [Sector.Power, Sector.SectorCoupled],
-  technique: [Technique.MILP, Technique.LP],
-  kindOfProblem: [
-    KindOfProblem.Infrastructure,
-    KindOfProblem.Operational,
-    KindOfProblem.DCOptimalPowerFlow,
-    KindOfProblem.SteadyStateOptimalPowerFlow,
-  ],
-  modelName: [
-    Model.PyPSA,
-    Model.PyPSAEur,
-    Model.PowerModel,
-    Model.Tulipa,
-    Model.Sienna,
-    Model.GenX,
-    Model.TEMOA,
-  ],
-  problemSize: [
-    ProblemSize.L,
-    ProblemSize.M,
-    ProblemSize.S,
-    ProblemSize.XS,
-    ProblemSize.XXS,
-  ],
+const initialState: IFilterState = {
   benchmarks: [],
+  kindOfProblem: [],
+  modelName: [],
+  problemSize: [],
+  sectors: [],
   solvers: [],
   statuses: [],
+  technique: [],
 }
 
 const filterReducer = (
-  state: FilterState = initialState,
+  state: IFilterState = initialState,
   action: AnyAction
-): FilterState => {
+): IFilterState => {
   switch (action.type) {
+    case SET_FILTER:
+      return {
+        ...state,
+        ...action.payload,
+      }
     case TOGGLE_FILTER:
       const { category, value, only } = action.payload as {
-        category: keyof FilterState
-        value: Sector | Technique | KindOfProblem | Model | ProblemSize
+        category: keyof IFilterState
+        value: string
         only: boolean
       }
 

--- a/website-nextjs/src/redux/results/actions.ts
+++ b/website-nextjs/src/redux/results/actions.ts
@@ -1,5 +1,6 @@
 import { BenchmarkResult } from "@/types/benchmark"
 import { MetaData } from "@/types/meta-data"
+import { IAvailableFilterData } from "@/types/state"
 
 const actions = {
   SET_BENCHMARK_RESULTS: "SET_BENCHMARK_RESULTS",
@@ -7,6 +8,7 @@ const actions = {
   SET_META_DATA: "SET_META_DATA",
   SET_RAW_BENCHMARK_RESULTS: "SET_RAW_BENCHMARK_RESULTS",
   SET_RAW_META_DATA: "SET_RAW_META_DATA",
+  SET_AVAILABLE_FILTER_DATA: "SET_AVAILABLE_FILTER_DATA",
 
   setBenchmarkResults: (results: BenchmarkResult[]) => {
     return {
@@ -20,10 +22,10 @@ const actions = {
       payload: { results },
     }
   },
-  setMetaData: (results: MetaData) => {
+  setMetaData: (metaData: MetaData) => {
     return {
       type: actions.SET_META_DATA,
-      payload: { results },
+      payload: { metaData },
     }
   },
   setRawBenchmarkResults: (results: BenchmarkResult[]) => {
@@ -32,10 +34,16 @@ const actions = {
       payload: { results },
     }
   },
-  setRawMetaData: (results: MetaData) => {
+  setRawMetaData: (metaData: MetaData) => {
     return {
       type: actions.SET_RAW_META_DATA,
-      payload: { results },
+      payload: { metaData },
+    }
+  },
+  setAvailableFilterData: (availableFilterData: IAvailableFilterData) => {
+    return {
+      type: actions.SET_AVAILABLE_FILTER_DATA,
+      payload: { availableFilterData },
     }
   },
 }

--- a/website-nextjs/src/redux/results/reducer.ts
+++ b/website-nextjs/src/redux/results/reducer.ts
@@ -2,8 +2,9 @@ import { AnyAction } from "redux"
 
 import actions from "./actions"
 import { BenchmarkResult } from "@/types/benchmark"
-import { MetaData } from "@/types/meta-data"
 import { formatBenchmarkName, processBenchmarkResults } from "@/utils/results"
+import { IResultState } from "@/types/state"
+import { sortStringArray } from "@/utils/string"
 
 const {
   SET_BENCHMARK_RESULTS,
@@ -11,39 +12,27 @@ const {
   SET_META_DATA,
   SET_RAW_BENCHMARK_RESULTS,
   SET_RAW_META_DATA,
+  SET_AVAILABLE_FILTER_DATA,
 } = actions
 
-export type ResultState = {
-  benchmarkResults: BenchmarkResult[]
-  benchmarkLatestResults: BenchmarkResult[]
-  metaData: MetaData
-  rawBenchmarkResults: BenchmarkResult[]
-  rawMetaData: MetaData
-  years: number[]
-  solvers: string[]
-  availableBenchmarksAndSizes: string[]
-  availableBenchmarks: string[]
-  availableSolves: string[]
-  solversData: {
-    solver: string
-    versions: string[]
-  }[]
-  availableStatuses: string[]
-}
-
-const initialState: ResultState = {
-  benchmarkResults: [],
+const initialState: IResultState = {
+  availableBenchmarks: [],
+  availableBenchmarksAndSizes: [],
+  availableKindOfProblems: [],
+  availableModels: [],
+  availableProblemSizes: [],
+  availableSectors: [],
+  availableSolves: [],
+  availableStatuses: [],
+  availableTechniques: [],
   benchmarkLatestResults: [],
+  benchmarkResults: [],
   metaData: {},
   rawBenchmarkResults: [],
   rawMetaData: {},
-  years: [],
   solvers: [],
-  availableBenchmarksAndSizes: [],
-  availableBenchmarks: [],
-  availableSolves: [],
   solversData: [],
-  availableStatuses: [],
+  years: [],
 }
 
 const benchmarkResultsReducer = (state = initialState, action: AnyAction) => {
@@ -108,12 +97,29 @@ const benchmarkResultsReducer = (state = initialState, action: AnyAction) => {
     case SET_META_DATA:
       return {
         ...state,
-        metaData: action.payload.results,
+        metaData: action.payload.metaData,
       }
     case SET_RAW_META_DATA:
       return {
         ...state,
-        rawMetaData: action.payload.results,
+        rawMetaData: action.payload.metaData,
+      }
+
+    case SET_AVAILABLE_FILTER_DATA:
+      const {
+        availableSectors,
+        availableTechniques,
+        availableKindOfProblems,
+        availableModels,
+        availableProblemSizes,
+      } = action.payload.availableFilterData
+      return {
+        ...state,
+        availableSectors: sortStringArray(availableSectors),
+        availableTechniques: sortStringArray(availableTechniques),
+        availableKindOfProblems: sortStringArray(availableKindOfProblems),
+        availableModels: sortStringArray(availableModels),
+        availableProblemSizes: sortStringArray(availableProblemSizes, "desc"),
       }
 
     default:

--- a/website-nextjs/src/types/meta-data.ts
+++ b/website-nextjs/src/types/meta-data.ts
@@ -1,4 +1,3 @@
-import { KindOfProblem, Model, Sector, Technique } from "@/constants"
 
 type Size = {
   spatialResolution: number
@@ -9,11 +8,11 @@ type Size = {
 
 interface MetaDataEntry {
   shortDescription: string
-  modelName: Model
+  modelName: string
   version: string | null
-  technique: Technique
-  kindOfProblem: KindOfProblem
-  sectors: Sector
+  technique: string
+  kindOfProblem: string
+  sectors: string
   timeHorizon: string
   milpFeatures: string | null
   sizes: Size[]

--- a/website-nextjs/src/types/state.ts
+++ b/website-nextjs/src/types/state.ts
@@ -1,0 +1,41 @@
+import { BenchmarkResult } from "./benchmark"
+import { MetaData } from "./meta-data"
+
+export type IFilterState = {
+    sectors: string[]
+    technique: string[]
+    kindOfProblem: string[]
+    problemSize: string[]
+    modelName: string[]
+    benchmarks: string[]
+    solvers: string[]
+    statuses: string[]
+  }
+
+
+export interface IAvailableFilterData {
+  availableSectors: string[]
+  availableTechniques: string[]
+  availableKindOfProblems: string[]
+  availableProblemSizes: string[]
+  availableModels: string[]
+}
+
+export interface IResultState extends IAvailableFilterData {
+  benchmarkResults: BenchmarkResult[]
+  benchmarkLatestResults: BenchmarkResult[]
+  metaData: MetaData
+  rawBenchmarkResults: BenchmarkResult[]
+  rawMetaData: MetaData
+  years: number[]
+  solvers: string[]
+  availableBenchmarksAndSizes: string[]
+  availableBenchmarks: string[]
+  availableSolves: string[]
+
+  solversData: {
+    solver: string
+    versions: string[]
+  }[]
+  availableStatuses: string[]
+}

--- a/website-nextjs/src/utils/meta-data.ts
+++ b/website-nextjs/src/utils/meta-data.ts
@@ -1,5 +1,6 @@
 import yaml from "yaml"
 import camelCase from "lodash.camelcase"
+import { MetaData } from "@/types/meta-data"
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function toCamelCase(obj: any, isTopLevel = true): unknown {
@@ -31,7 +32,7 @@ const fetchYamlData = async (filePath: string) => {
 
 const getMetaData = async () => {
   const rawData = await fetchYamlData("/results/metadata.yaml")
-  return toCamelCase(rawData)
+  return toCamelCase(rawData) as MetaData
 }
 
 const getInstance = (temporalResolution: string, spatialResolution: string) => {
@@ -40,4 +41,8 @@ const getInstance = (temporalResolution: string, spatialResolution: string) => {
   return `${spatialResolution}-${tempResolution}`
 }
 
-export { getMetaData, getInstance }
+const getUniqueValues = <T, K extends keyof T>(data: T[], key: K): T[K][] =>
+  Array.from(new Set(data.map(item => item[key])));
+
+
+export { getMetaData, getInstance, getUniqueValues }

--- a/website-nextjs/src/utils/number.ts
+++ b/website-nextjs/src/utils/number.ts
@@ -1,5 +1,7 @@
-const roundNumber = (value: number, digits = 0) => {
+const roundNumber = (value: number, digits = 0, defaultValue = 0) => {
   const multiplier = Math.pow(10, digits)
+  const result = Math.round(value * multiplier) / multiplier;
+  if (isNaN(result)) return defaultValue
   return Math.round(value * multiplier) / multiplier
 }
 

--- a/website-nextjs/src/utils/string.ts
+++ b/website-nextjs/src/utils/string.ts
@@ -1,0 +1,11 @@
+export function sortStringArray(
+  data: string[],
+  direction: "asc" | "desc" = "asc"
+): string[] {
+  const copy = [...data]
+  if (direction === "asc") {
+    return copy.sort((a, b) => a.localeCompare(b))
+  } else {
+    return copy.sort((a, b) => b.localeCompare(a))
+  }
+}


### PR DESCRIPTION
…round number

Fixed:
- DetailSection: change hardcoded timeout from 15min to 10min

- DetailSection: (${avaliableInstance.length} instances) is wrong as it changes when filters are applied, can it always be the total number of instances in the results?

- The values in the filter (e.g. TEMOA, or Sector coupled) should not be hard coded. Please can you get all available options from the metadata file? Otherwise it'll be hard to update the filters as we add new benchmarks.