### PR TITLE
Website: re-order things in the top details bar

### DIFF
--- a/website-nextjs/src/components/admin/DetailSection.tsx
+++ b/website-nextjs/src/components/admin/DetailSection.tsx
@@ -4,6 +4,7 @@ import {
   AppIcon,
   DatabaseIcon,
   GraphBarIcon,
+  HistoryIcon,
   LayoutGroupIcon,
   VectorSquareIcon,
 } from "@/assets/icons"
@@ -45,25 +46,6 @@ const DetailSection = () => {
 
   const detailData = [
     {
-      label: "Solvers",
-      value: availableSolvers.length,
-      icon: <VectorSquareIcon />,
-      generateLabel: () => (
-        <>
-          Solvers:{" "}
-          <span className="font-bold">
-            {availableSolvers.length} {`(${avaliableVersion.length}`} versions
-            {")"}
-          </span>
-        </>
-      ),
-    },
-    {
-      label: "Iteration",
-      value: "1",
-      icon: <LayoutGroupIcon />,
-    },
-    {
       label: "Benchmarks",
       value: availableBenchmarksCount,
       icon: <GraphBarIcon />,
@@ -78,6 +60,30 @@ const DetailSection = () => {
       ),
     },
     {
+      label: "Solvers",
+      value: availableSolvers.length,
+      icon: <VectorSquareIcon />,
+      generateLabel: () => (
+        <>
+          Solvers:{" "}
+          <span className="font-bold">
+            {availableSolvers.length} {`(${avaliableVersion.length}`} versions
+            {")"}
+          </span>
+        </>
+      ),
+    },
+    {
+      label: "Iterations",
+      value: "1",
+      icon: <LayoutGroupIcon />,
+    },
+    {
+      label: "vCPUs",
+      value: "2 (1 core)",
+      icon: <AppIcon />,
+    },
+    {
       label: "Memory",
       value: "16 GB",
       icon: <DatabaseIcon />,
@@ -85,12 +91,7 @@ const DetailSection = () => {
     {
       label: "Timeout",
       value: "10 min",
-      icon: <DatabaseIcon />,
-    },
-    {
-      label: "vCPUs",
-      value: "2 (1 core)",
-      icon: <AppIcon />,
+      icon: <HistoryIcon />,
     },
   ]
 


### PR DESCRIPTION
Re-ordered the items in this top bar:
![image](https://github.com/user-attachments/assets/3ddca888-e309-4f29-a1cf-8663c5294199)

Also, I changed the icon for timeout to be more "time" related. But in the future, can we find something more appropriate, like an hourglass?