### PR TITLE
Implement reference benchmark

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v4.2.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -128,6 +128,7 @@ Each YAML file defines a benchmark with specific configuration:
 | `enable_gcs_upload` | Enable/disable results upload to GCS bucket                | true               |
 | `gcs_bucket_name` | Name of the GCS bucket to upload the results               | solver-benchmarks  |
 | `auto_destroy_vm` | Enable/disable auto deletion of VM on benchmark completion | true               |
+| `reference_benchmark_interval` | Time interval in seconds to run the reference benchmark    | 3600               |
 | `ssh_user` | SSH username                                               | ""                 |
 | `ssh_key_path` | Path to SSH public key                                     | ""                 |
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -73,6 +73,12 @@ variable "auto_destroy_vm" {
   default     = true
 }
 
+variable "reference_benchmark_interval" {
+  description = "Time interval in seconds for running reference benchmarks (0 disables reference benchmarks)"
+  type        = number
+  default     = 3600
+}
+
 locals {
   benchmark_files = fileset("${path.module}/benchmarks", "*.yaml*")
 
@@ -124,6 +130,7 @@ resource "google_compute_instance" "benchmark_instances" {
     auto_destroy_vm = tostring(var.auto_destroy_vm)
     project_id = var.project_id
     zone = var.zone
+    reference_benchmark_interval = tostring(var.reference_benchmark_interval)
   }
 
   # Add the startup script from external file

--- a/runner/benchmark_all.sh
+++ b/runner/benchmark_all.sh
@@ -4,15 +4,17 @@ set -euo pipefail
 
 # Parse command line arguments
 usage() {
-    echo "Usage: $0 [-a] [-y \"<space separated years>\"] <benchmarks yaml file>"
+    echo "Usage: $0 [-a] [-y \"<space separated years>\"] [-r <seconds>] <benchmarks yaml file>"
     echo "Runs the solvers from the specified years (default all) on the benchmarks in the given file"
     echo "Options:"
     echo "    -a    Append to the results CSV file instead of overwriting. Default: overwrite"
     echo "    -y    A space separated string of years to run. Default: 2020 2021 2022 2023 2024"
+    echo "    -r    Reference benchmark interval in seconds. Default: 0 (disabled)"
 }
 overwrite_results="true"
 years=(2020 2021 2022 2023 2024)
-while getopts "hay:" flag
+reference_interval=0  # Default: disabled
+while getopts "hay:r:" flag
 do
     case ${flag} in
     h)  usage
@@ -22,6 +24,9 @@ do
         overwrite_results="false"
         ;;
     y)  IFS=', ' read -r -a years <<< "$OPTARG"
+        ;;
+    r)  reference_interval="$OPTARG"
+        echo "Reference benchmark will run every $reference_interval seconds"
         ;;
     esac
 done
@@ -52,9 +57,9 @@ for year in "${years[@]}"; do
     echo "Running benchmarks for the year: $year"
     conda activate "$env_name"
     if [ "$idx" -eq 0 ]; then
-        python "$BENCHMARK_SCRIPT" "$BENCHMARKS_FILE" "$year" "$overwrite_results"
+        python "$BENCHMARK_SCRIPT" "$BENCHMARKS_FILE" "$year" "$overwrite_results" "$reference_interval"
     else
-        python "$BENCHMARK_SCRIPT" "$BENCHMARKS_FILE" "$year" false
+        python "$BENCHMARK_SCRIPT" "$BENCHMARKS_FILE" "$year" false "$reference_interval"
     fi
     conda deactivate
 

--- a/runner/run_benchmarks.py
+++ b/runner/run_benchmarks.py
@@ -393,6 +393,10 @@ def main(
         + ("" if size_categories is None else f" matching {size_categories}")
     )
 
+    reference_solver_version = ""
+    if reference_interval > 0:
+        reference_solver_version = get_highs_binary_version()
+
     for benchmark in processed_benchmarks:
         for solver in solvers:
             solver_version = solvers_versions.get(solver)
@@ -464,7 +468,7 @@ def main(
                     # Add required fields to reference metrics
                     reference_metrics["size"] = "reference"
                     reference_metrics["solver"] = "highs-binary"
-                    reference_metrics["solver_version"] = get_highs_binary_version()
+                    reference_metrics["solver_version"] = reference_solver_version
                     reference_metrics["solver_release_year"] = "N/A"
 
                     # Record reference benchmark results


### PR DESCRIPTION
Introduces optional periodic reference benchmark runs.

If testing before merging this to `main`, you should add something like:
```
cd /solver-benchmark
git checkout reference-benchmark
cd ..
```
to the startup-script.sh after cloning the benchmark repo.