### PR TITLE
Benchmarks: fix some size instance names to be consistent

### DIFF
--- a/benchmarks/jump_highs_platform/metadata_sienna.yaml
+++ b/benchmarks/jump_highs_platform/metadata_sienna.yaml
@@ -12,7 +12,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon12_Day29-082507660a1ec655fed92d2b6d49a1d606f029e30cb0dfcd4915f8b8ce896f2e.mps.gz
       Temporal resolution: 12
@@ -35,7 +35,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon12_Day314-16130d073126ae057331ac06d84b99ec39ec673d90e6905b97d4a63326b48708.mps.gz
       Temporal resolution: 12
@@ -58,7 +58,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon12_Day332-3bf569a3c3108f4dde780873e6eabe9461cb9432af281c716efacfbad4837ba1.mps.gz
       Temporal resolution: 12
@@ -81,7 +81,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon24_Day29-fc330569fd9116b60a77ce31693e7b88ae4137cb463d769b9e21adf49c1eb6f1.mps.gz
       Temporal resolution: 24
@@ -106,7 +106,7 @@ benchmarks:
     spatial resolution: 73
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon24_Day314-a9522cdcf8178254104ce7ca6f4fff4e2554e5844cb8b92a338635cdf211ef2a.mps.gz
       Temporal resolution: 24
@@ -129,7 +129,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon24_Day332-35f61df3d7e00db245b09ef67b21ea954c6bbff05511cb1702cd419bd7fd2711.mps.gz
       Temporal resolution: 24
@@ -152,7 +152,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon48_Day29-bc96d26484b652f0ec372e43ddf2b30aa8af03386a3a5d7ee65200d1dc97e4b0.mps.gz
       Temporal resolution: 48
@@ -175,7 +175,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon48_Day314-2b77a5de6b6f96cfa72c7ec7940a1f701ee898ee8014816b7dc644baff15a89c.mps.gz
       Temporal resolution: 48
@@ -198,7 +198,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon48_Day332-1a6c28ae9bd6ab741441e47b9ec4ceddbbeb31eea0e243dddcea414d84171583.mps.gz
       Temporal resolution: 48
@@ -221,7 +221,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon12_Day29-0b223b43ed886810bf678ef53e6242e07e1528daff59505cb15567625fb866f2.mps.gz
       Temporal resolution: 12
@@ -244,7 +244,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon12_Day314-11b79112e8b2da7a756189e831d00d40b9bf05069c6b59183e7d88fa28da392a.mps.gz
       Temporal resolution: 12
@@ -267,7 +267,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon12_Day332-1079c962fa915ebe34bf2be8be82c6aed03bccea348410a8dc5f5d83a4a3dff1.mps.gz
       Temporal resolution: 12
@@ -290,7 +290,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon24_Day29-12a9e8c3e475aa02d68692347b1fbed9f4769d3b89c3d5f803ebcf8e06d05197.mps.gz
       Temporal resolution: 24
@@ -313,7 +313,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon24_Day314-a50a463915826563a3430374d34d27cf5cc7e7e8d4fce55b2371e6c12b261455.mps.gz
       Temporal resolution: 24
@@ -336,7 +336,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon24_Day332-2afa1ade7ab1d59c4ca58bc59ba2c50538c809c3951a7961f8f68a489bdee719.mps.gz
       Temporal resolution: 24
@@ -359,7 +359,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon48_Day29-dbf0e850812c48d60a10754b5a57f6ccc4fea126abd3fba4e32d68277501ca80.mps.gz
       Temporal resolution: 24
@@ -382,7 +382,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon48_Day314-534efa06a79fce256e898897b9f5fbeaab4294bdbf86b2650961ed940effb1a2.mps.gz
       Temporal resolution: 24
@@ -405,7 +405,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon48_Day332-a4c0a55a6159313ab87daae5e03fb8a9faca21d44bc6bd4ed085d46357eec3a7.mps.gz
       Temporal resolution: 48
@@ -428,7 +428,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon12_Day29-584e340fc9e79c75e07daa790d8b956d159a81187e25c077b3d5666039d25e75.mps.gz
       Temporal resolution: 12
@@ -451,7 +451,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon12_Day314-4ea0f31269b786b7a96c59cf7ae7a7a6b782a96461ba9a05ca24091afa77b303.mps.gz
       Temporal resolution: 12
@@ -474,7 +474,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon12_Day332-94334977dd58464a000d3aa3515f45dce7afc672326d685df3a58b702508af0a.mps.gz
       Temporal resolution: 12
@@ -497,7 +497,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon24_Day29-273c75c90ebdad62f763619da32a0e44b6456f076aeff7345e8603659a19b3ee.mps.gz
       Temporal resolution: 24
@@ -520,7 +520,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon24_Day314-11aaca595a3ad6a8619f2e510a9fbcf9169b22449c76dd46776df829ab9aba64.mps.gz
       Temporal resolution: 24
@@ -543,7 +543,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon24_Day332-15df931033d1a5a3f0133bd141798d3b02c4211befb6f25c19e8218797a05447.mps.gz
       Temporal resolution: 24
@@ -566,7 +566,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon48_Day29-8cabe382d8293ca2c795321015d05603b54f9dbf2dbcfff3e9116c367bd42eac.mps.gz
       Temporal resolution: 48
@@ -589,7 +589,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon48_Day314-7fa7bf7b284cfc8f93c2541d159617c4964c40daf64cff299f083ba81c25b5ad.mps.gz
       Temporal resolution: 48
@@ -612,7 +612,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon48_Day332-864c7b757abad07ecb724ec46ef134aedc73ae5d286ce16129a9c913dd9a0975.mps.gz
       Temporal resolution: 48
@@ -635,7 +635,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon12_Day29-4c0d0a8855ccd93b4831a532eedc3d0dc9f33df77c1e98cf81e9834713337b60.mps.gz
       Temporal resolution: 12
@@ -658,7 +658,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon12_Day314-0bb1986753999d5831bc4345e6ce53f547ea0849b129fd761809e36d4a9906b4.mps.gz
       Temporal resolution: 12
@@ -681,7 +681,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon12_Day332-9329d35ea14edb840379be5519aa15021d5cfdbedec342326b9165ca6f0abc05.mps.gz
       Temporal resolution: 12
@@ -704,7 +704,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon24_Day29-66258a0e8497e1e17a702b769ebc9c4dcb1ef285993d4f1f41d9dda59878c5cc.mps.gz
       Temporal resolution: 24
@@ -727,7 +727,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon24_Day314-868ad371df2ae99f1427c0d6f5d6af4f1c520d51224598e1dc085b0736df5955.mps.gz
       Temporal resolution: 24
@@ -750,7 +750,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon24_Day332-b8b4fb5c2c4b0a5f18333028c8d9a7de9d11a5607bb8b660b73cd8a2f617d26a.mps.gz
       Temporal resolution: 24
@@ -773,7 +773,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon48_Day29-baddda2ca9ed73b7a9935f88b30a217e31cfa48670e659a44d07142f65039029.mps.gz
       Temporal resolution: 48
@@ -796,7 +796,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon48_Day314-ec745b9b237a474e1ed2a2ef455cba4c7cc926d59742ae1fd4930415cc1a46d4.mps.gz
       Temporal resolution: 48
@@ -819,7 +819,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon48_Day332-c5f9c340dae227b689ac284a47d285373a0cd023658a17e9e56bc68136fad3de.mps.gz
       Temporal resolution: 48

--- a/benchmarks/times/metadata.yaml
+++ b/benchmarks/times/metadata.yaml
@@ -232,7 +232,7 @@ benchmarks:
     Time horizon: Single-stage (1 year)
     MILP features: None
     Sizes:
-    - Name: 1-1h
+    - Name: 1-1
       Size: M
       URL: https://storage.googleapis.com/solver-benchmarks/times-nom-ts1-p39.mps
       Temporal resolution: 1
@@ -240,7 +240,7 @@ benchmarks:
       Realistic: false
       Num. constraints: 415261
       Num. variables: 544694
-    - Name: 40-1h
+    - Name: 40-1ts
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/times-nom-ts40-p39.mps
       Temporal resolution: 1
@@ -261,7 +261,7 @@ benchmarks:
     Time horizon: Single-stage
     MILP features: None
     Sizes:
-    - Name: 26-1h
+    - Name: 26-1ts
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/times-nom-ts1-p39-counties.mps
       Temporal resolution: 1
@@ -282,7 +282,7 @@ benchmarks:
     Time horizon: Single-stage
     MILP features: None
     Sizes:
-    - Name: 2-24h
+    - Name: 2-24ts
       Size: M
       URL: https://storage.googleapis.com/solver-benchmarks/kea.mps
       Temporal resolution: 24
@@ -304,7 +304,7 @@ benchmarks:
     Time horizon: Single stage
     MILP features: None
     Sizes:
-    - Name: 2-24h
+    - Name: 2-24ts
       Size: M
       URL: https://storage.googleapis.com/solver-benchmarks/tui.mps
       Temporal resolution: 24

--- a/results/metadata.yaml
+++ b/results/metadata.yaml
@@ -683,7 +683,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon12_Day29-082507660a1ec655fed92d2b6d49a1d606f029e30cb0dfcd4915f8b8ce896f2e.mps.gz
       Temporal resolution: 12
@@ -707,7 +707,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon12_Day314-16130d073126ae057331ac06d84b99ec39ec673d90e6905b97d4a63326b48708.mps.gz
       Temporal resolution: 12
@@ -731,7 +731,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon12_Day332-3bf569a3c3108f4dde780873e6eabe9461cb9432af281c716efacfbad4837ba1.mps.gz
       Temporal resolution: 12
@@ -755,7 +755,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon24_Day29-fc330569fd9116b60a77ce31693e7b88ae4137cb463d769b9e21adf49c1eb6f1.mps.gz
       Temporal resolution: 24
@@ -781,7 +781,7 @@ benchmarks:
     spatial resolution: 73
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon24_Day314-a9522cdcf8178254104ce7ca6f4fff4e2554e5844cb8b92a338635cdf211ef2a.mps.gz
       Temporal resolution: 24
@@ -805,7 +805,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon24_Day332-35f61df3d7e00db245b09ef67b21ea954c6bbff05511cb1702cd419bd7fd2711.mps.gz
       Temporal resolution: 24
@@ -829,7 +829,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon48_Day29-bc96d26484b652f0ec372e43ddf2b30aa8af03386a3a5d7ee65200d1dc97e4b0.mps.gz
       Temporal resolution: 48
@@ -853,7 +853,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon48_Day314-2b77a5de6b6f96cfa72c7ec7940a1f701ee898ee8014816b7dc644baff15a89c.mps.gz
       Temporal resolution: 48
@@ -877,7 +877,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon48_Day332-1a6c28ae9bd6ab741441e47b9ec4ceddbbeb31eea0e243dddcea414d84171583.mps.gz
       Temporal resolution: 48
@@ -900,7 +900,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon12_Day29-0b223b43ed886810bf678ef53e6242e07e1528daff59505cb15567625fb866f2.mps.gz
       Temporal resolution: 12
@@ -923,7 +923,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon12_Day314-11b79112e8b2da7a756189e831d00d40b9bf05069c6b59183e7d88fa28da392a.mps.gz
       Temporal resolution: 12
@@ -946,7 +946,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon12_Day332-1079c962fa915ebe34bf2be8be82c6aed03bccea348410a8dc5f5d83a4a3dff1.mps.gz
       Temporal resolution: 12
@@ -969,7 +969,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon24_Day29-12a9e8c3e475aa02d68692347b1fbed9f4769d3b89c3d5f803ebcf8e06d05197.mps.gz
       Temporal resolution: 24
@@ -992,7 +992,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon24_Day314-a50a463915826563a3430374d34d27cf5cc7e7e8d4fce55b2371e6c12b261455.mps.gz
       Temporal resolution: 24
@@ -1015,7 +1015,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon24_Day332-2afa1ade7ab1d59c4ca58bc59ba2c50538c809c3951a7961f8f68a489bdee719.mps.gz
       Temporal resolution: 24
@@ -1038,7 +1038,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon48_Day29-dbf0e850812c48d60a10754b5a57f6ccc4fea126abd3fba4e32d68277501ca80.mps.gz
       Temporal resolution: 24
@@ -1061,7 +1061,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon48_Day314-534efa06a79fce256e898897b9f5fbeaab4294bdbf86b2650961ed940effb1a2.mps.gz
       Temporal resolution: 24
@@ -1084,7 +1084,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetDC_Horizon48_Day332-a4c0a55a6159313ab87daae5e03fb8a9faca21d44bc6bd4ed085d46357eec3a7.mps.gz
       Temporal resolution: 48
@@ -1108,7 +1108,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon12_Day29-584e340fc9e79c75e07daa790d8b956d159a81187e25c077b3d5666039d25e75.mps.gz
       Temporal resolution: 12
@@ -1132,7 +1132,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon12_Day314-4ea0f31269b786b7a96c59cf7ae7a7a6b782a96461ba9a05ca24091afa77b303.mps.gz
       Temporal resolution: 12
@@ -1156,7 +1156,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon12_Day332-94334977dd58464a000d3aa3515f45dce7afc672326d685df3a58b702508af0a.mps.gz
       Temporal resolution: 12
@@ -1180,7 +1180,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon24_Day29-273c75c90ebdad62f763619da32a0e44b6456f076aeff7345e8603659a19b3ee.mps.gz
       Temporal resolution: 24
@@ -1204,7 +1204,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon24_Day314-11aaca595a3ad6a8619f2e510a9fbcf9169b22449c76dd46776df829ab9aba64.mps.gz
       Temporal resolution: 24
@@ -1228,7 +1228,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon24_Day332-15df931033d1a5a3f0133bd141798d3b02c4211befb6f25c19e8218797a05447.mps.gz
       Temporal resolution: 24
@@ -1252,7 +1252,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon48_Day29-8cabe382d8293ca2c795321015d05603b54f9dbf2dbcfff3e9116c367bd42eac.mps.gz
       Temporal resolution: 48
@@ -1276,7 +1276,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon48_Day314-7fa7bf7b284cfc8f93c2541d159617c4964c40daf64cff299f083ba81c25b5ad.mps.gz
       Temporal resolution: 48
@@ -1300,7 +1300,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetPTDF_Horizon48_Day332-864c7b757abad07ecb724ec46ef134aedc73ae5d286ce16129a9c913dd9a0975.mps.gz
       Temporal resolution: 48
@@ -1323,7 +1323,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon12_Day29-4c0d0a8855ccd93b4831a532eedc3d0dc9f33df77c1e98cf81e9834713337b60.mps.gz
       Temporal resolution: 12
@@ -1346,7 +1346,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon12_Day314-0bb1986753999d5831bc4345e6ce53f547ea0849b129fd761809e36d4a9906b4.mps.gz
       Temporal resolution: 12
@@ -1369,7 +1369,7 @@ benchmarks:
     Time horizon: Single stage (12 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-12
       Size: S
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon12_Day332-9329d35ea14edb840379be5519aa15021d5cfdbedec342326b9165ca6f0abc05.mps.gz
       Temporal resolution: 12
@@ -1392,7 +1392,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon24_Day29-66258a0e8497e1e17a702b769ebc9c4dcb1ef285993d4f1f41d9dda59878c5cc.mps.gz
       Temporal resolution: 24
@@ -1415,7 +1415,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon24_Day314-868ad371df2ae99f1427c0d6f5d6af4f1c520d51224598e1dc085b0736df5955.mps.gz
       Temporal resolution: 24
@@ -1438,7 +1438,7 @@ benchmarks:
     Time horizon: Single stage (24 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-24
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon24_Day332-b8b4fb5c2c4b0a5f18333028c8d9a7de9d11a5607bb8b660b73cd8a2f617d26a.mps.gz
       Temporal resolution: 24
@@ -1461,7 +1461,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon48_Day29-baddda2ca9ed73b7a9935f88b30a217e31cfa48670e659a44d07142f65039029.mps.gz
       Temporal resolution: 48
@@ -1484,7 +1484,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon48_Day314-ec745b9b237a474e1ed2a2ef455cba4c7cc926d59742ae1fd4930415cc1a46d4.mps.gz
       Temporal resolution: 48
@@ -1507,7 +1507,7 @@ benchmarks:
     Time horizon: Single stage (48 hours)
     MILP features: Unit commitment
     Sizes:
-    - Name: 1-1h
+    - Name: 73-48
       Size: M
       URL: https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetTransport_Horizon48_Day332-c5f9c340dae227b689ac284a47d285373a0cd023658a17e9e56bc68136fad3de.mps.gz
       Temporal resolution: 48
@@ -2583,7 +2583,7 @@ benchmarks:
     Time horizon: Single-stage (1 year)
     MILP features: None
     Sizes:
-    - Name: 1-1h
+    - Name: 1-1
       Size: M
       URL: https://storage.googleapis.com/solver-benchmarks/times-nom-ts1-p39.mps
       Temporal resolution: 1
@@ -2591,7 +2591,7 @@ benchmarks:
       Realistic: false
       Num. constraints: 415261
       Num. variables: 544694
-    - Name: 40-1h
+    - Name: 40-1ts
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/times-nom-ts40-p39.mps
       Temporal resolution: 1
@@ -2612,7 +2612,7 @@ benchmarks:
     Time horizon: Single-stage
     MILP features: None
     Sizes:
-    - Name: 26-1h
+    - Name: 26-1ts
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/times-nom-ts1-p39-counties.mps
       Temporal resolution: 1
@@ -2634,7 +2634,7 @@ benchmarks:
     Time horizon: Single-stage
     MILP features: None
     Sizes:
-    - Name: 2-24h
+    - Name: 2-24ts
       Size: M
       URL: https://storage.googleapis.com/solver-benchmarks/kea.mps
       Temporal resolution: 24
@@ -2657,7 +2657,7 @@ benchmarks:
     Time horizon: Single stage
     MILP features: None
     Sizes:
-    - Name: 2-24h
+    - Name: 2-24ts
       Size: M
       URL: https://storage.googleapis.com/solver-benchmarks/tui.mps
       Temporal resolution: 24


### PR DESCRIPTION
This PR updates the size instance names of some benchmarks so that all of them follow a consistent naming convention. 

Updating benchmark names or size names is problematic because it is the unique identifier that ties together the metadata to the results, logs, and solution files. So if we want to update the names, we should either re-run those benchmarks, or if there are too many then we should write a migration script to update the results/logs/solutions accordingly.

Let's collect all the renamings that we want to do in this branch and decide on which option is best. (cc @KristijanFaust-OET @danielelerede-oet )