### PR TITLE
Website: Hide log download link for Gurobi solver in DataTable

### DIFF
--- a/website-nextjs/src/components/admin/benchmark-detail/DataTable.tsx
+++ b/website-nextjs/src/components/admin/benchmark-detail/DataTable.tsx
@@ -162,14 +162,20 @@ const DataTable = ({ benchmarkName }: DataTableProps) => {
         header: "Log",
         accessorKey: "log",
         size: 105,
-        cell: (info: CellContext<TableData, unknown>) => (
-          <Link
-            href={info.getValue() as string}
-            className="text-white bg-green-pop p-2 py-1.5 rounded-lg text-sm"
-          >
-            Download Log
-          </Link>
-        ),
+        cell: (info: CellContext<TableData, unknown>) => {
+          const solver = info.row.original?.solver;
+          if (solver === "gurobi") {
+            return <></>;
+          }
+          return (
+            <Link
+              href={info.getValue() as string}
+              className="text-white bg-green-pop p-2 py-1.5 rounded-lg text-sm"
+            >
+              Download Log
+            </Link>
+          );
+        },
       },
       {
         header: "Solution",


### PR DESCRIPTION
<img width="2322" height="1074" alt="image" src="https://github.com/user-attachments/assets/e758aa1d-5d6a-4f1b-8d9a-61b661265d1a" />
