### PR TITLE
Add benchmark models

### DIFF
--- a/benchmarks/zen_garden/metadata.yaml
+++ b/benchmarks/zen_garden/metadata.yaml
@@ -1,7 +1,7 @@
 ## https://github.com/ZEN-universe/ZEN-garden
 benchmarks:
   zen-garden-eur-PI:
-    Short description: Model of the European transition pathway for the electricity and heating sectors of 28 European countries from 2022 to 2050. Performs time series aggregation under perfect foresight and instantaneous technology expansion.
+    Short description: Model of the European transition pathway for the electricity and heating sectors of 28 European countries from 2022 to 2050. Performs time series aggregation under perfect foresight and instantaneous technology expansion. A cumulative carbon budget is set for the carbon emissions.
     Modelling framework: ZEN-garden
     Model name: ZEN-garden-PI
     Version:
@@ -67,3 +67,69 @@ benchmarks:
       Realistic motivation: Sufficient spatial and temporal resolution over the considered time horizon to allow the benchmark to be defined as Realistic.
       Num. constraints: # Automatically assigned when running the benchmark
       Num. variables: # Automatically assigned when running the benchmark
+  zen-garden-eur-PI-annual-emission-limit:
+    Short description: Model of the European transition pathway for the electricity and heating sectors of 28 European countries from 2022 to 2050. Performs time series aggregation under perfect foresight and instantaneous technology expansion. Annual emissions targets are set for each year resulting in the same carbon emissions as the carbon emission budget.
+    Modelling framework: ZEN-garden
+    Model name: ZEN-garden-PI-annual-emission-limit
+    Version:
+    Contributor(s)/Source: Jacob Mannhardt, Reliability and Risk Engineering, Institute of Energy and Process Engineering, ETH Zürich
+    Problem class: LP
+    Application: Infrastructure & Capacity Expansion
+    Sectoral focus: Sector-coupled
+    Sectors: Electric, Heating
+    Time horizon: Multi-stage (15 stages)
+    MILP features: None
+    Sizes:
+      - Name: 28-100ts
+        Size: # Automatically assigned when running the benchmark
+        URL: https://drive.google.com/drive/folders/1zpFhsmQwWixkDvF9_tbT4qIH75nsM9UC?usp=sharing
+        Temporal resolution: 100 time slices
+        Spatial resolution: 28 nodes
+        Realistic: true
+        Realistic motivation: Sufficient spatial and temporal resolution over the considered time horizon to allow the benchmark to be defined as Realistic.
+        Num. constraints: # Automatically assigned when running the benchmark
+        Num. variables: # Automatically assigned when running the benchmark
+  zen-garden-eur-PI-constrained-expansion:
+    Short description: Model of the European transition pathway for the electricity and heating sectors of 28 European countries from 2022 to 2050. Performs time series aggregation under perfect foresight and constrained technology expansion. A cumulative carbon budget is set for the carbon emissions.
+    Modelling framework: ZEN-garden
+    Model name: ZEN-garden-PI-constrained-expansion
+    Version:
+    Contributor(s)/Source: Jacob Mannhardt, Reliability and Risk Engineering, Institute of Energy and Process Engineering, ETH Zürich
+    Problem class: LP
+    Application: Infrastructure & Capacity Expansion
+    Sectoral focus: Sector-coupled
+    Sectors: Electric, Heating
+    Time horizon: Multi-stage (15 stages)
+    MILP features: None
+    Sizes:
+      - Name: 28-100ts
+        Size: # Automatically assigned when running the benchmark
+        URL: https://drive.google.com/drive/folders/11EiArNqSdn49voTqmTYfJJO5-2XtBWJj?usp=sharing
+        Temporal resolution: 100 time slices
+        Spatial resolution: 28 nodes
+        Realistic: true
+        Realistic motivation: Sufficient spatial and temporal resolution over the considered time horizon to allow the benchmark to be defined as Realistic.
+        Num. constraints: # Automatically assigned when running the benchmark
+        Num. variables: # Automatically assigned when running the benchmark
+  zen-garden-eur-PI-no-storage:
+    Short description: Model of the European transition pathway for the electricity and heating sectors of 28 European countries from 2022 to 2050. Performs time series aggregation under perfect foresight and instantaneous technology expansion without storage technologies. A cumulative carbon budget is set for the carbon emissions.
+    Modelling framework: ZEN-garden
+    Model name: ZEN-garden-PI-no-storage
+    Version:
+    Contributor(s)/Source: Jacob Mannhardt, Reliability and Risk Engineering, Institute of Energy and Process Engineering, ETH Zürich
+    Problem class: LP
+    Application: Infrastructure & Capacity Expansion
+    Sectoral focus: Sector-coupled
+    Sectors: Electric, Heating
+    Time horizon: Multi-stage (15 stages)
+    MILP features: None
+    Sizes:
+      - Name: 28-100ts
+        Size: # Automatically assigned when running the benchmark
+        URL: https://drive.google.com/drive/folders/1TG0mfHAd7HdqULxlREEWDqthpYAbvZ3X?usp=sharing
+        Temporal resolution: 100 time slices
+        Spatial resolution: 28 nodes
+        Realistic: true
+        Realistic motivation: Sufficient spatial and temporal resolution over the considered time horizon to allow the benchmark to be defined as Realistic.
+        Num. constraints: # Automatically assigned when running the benchmark
+        Num. variables: # Automatically assigned when running the benchmark


### PR DESCRIPTION
This PR adds 3 benchmark models of ZEN-garden.
1. zen-garden-eur-PI-annual-emission-limit: the same as PI_OEB_100 but with an annual emission target that results in the same cumulative emissions as the carbon emission budgets. This should simplify the problem as inter-annual time coupling is not required.
2. zen-garden-eur-PI-constrained-expansion: the same as PI_OEB_100 but with constrained technology expansion (adds a lot of complexity through inter-annual time coupling).
3. zen-garden-eur-PI-no-storage: the same as PI_OEB_100 but without storage technologies.