### PR TITLE
Fix link for genx-10_IEEE_9_bus_DC_OPF-no_uc

### DIFF
--- a/benchmarks/genx-lp/metadata.yaml
+++ b/benchmarks/genx-lp/metadata.yaml
@@ -120,7 +120,7 @@ benchmarks:
     Sizes:
     - Name: 9-1h
       Size: M
-      URL: https://storage.googleapis.com/solver-benchmarks/genx-6_three_zones_w_multistage-no_uc.lp
+      URL: https://storage.googleapis.com/solver-benchmarks/genx-10_IEEE_9_bus_DC_OPF-no_uc.lp
       Temporal resolution: 1 hour
       Spatial resolution: 9 nodes
       Realistic: true


### PR DESCRIPTION
Closes #321 .

This PR fixes the link for the `genx-10_IEEE_9_bus_DC_OPF-no_uc` benchmark.