### PR TITLE
Benchmarks: add ethos.fine.europe model

### DIFF
--- a/benchmarks/ethos.fine/metadata.yaml
+++ b/benchmarks/ethos.fine/metadata.yaml
@@ -16,7 +16,7 @@ benchmarks:
     Sizes:
     - Name: 175-720ts
       Size: L
-      URL: https://storage.googleapis.com/solver-benchmarks/ethos_fine_europe_60tp-175-720ts.mps
+      URL: https://storage.googleapis.com/solver-benchmarks/instances/ethos_fine_europe_60tp-175-720ts.mps.gz
       Temporal resolution: 720 time slices
       Spatial resolution: 175 nodes
       Realistic: false

--- a/results/metadata.yaml
+++ b/results/metadata.yaml
@@ -17,7 +17,7 @@ benchmarks:
     Sizes:
     - Name: 175-720ts
       Size: L
-      URL: https://storage.googleapis.com/solver-benchmarks/ethos_fine_europe_60tp-175-720ts.mps
+      URL: https://storage.googleapis.com/solver-benchmarks/instances/ethos_fine_europe_60tp-175-720ts.mps.gz
       Temporal resolution: 720 time slices
       Spatial resolution: 175 nodes
       Realistic: false


### PR DESCRIPTION
# Add ethos.fine.europe to solver benchmark.

Note that on our machines gurobi (with 8 threads) solves the model within 31000-3500 seconds, which is just below your timeout limit of 10h.
Also note the following gurobi solver settings that we are using:
> BarConvTol=1e-8 method=2 crossover=0 BarHomogeneous=1 ScaleFlag=1

I.e. we are only using barrier.


### Checklist

For PRs adding new benchmark instances:
- [x] I consent to releasing these benchmark instance files under the CC BY 4.0 license
- [x] I have tested that this model instance can be solved to optimality with gurobi solver [please indicate which solver]
- [ ] (Benchmark team) has tested that some solver solves these benchmarks within our timeouts

