### PR TITLE
Website: Fix typo in benchmark instance description

### DIFF
--- a/website-nextjs/src/components/admin/compare-solvers/SolverSelection.tsx
+++ b/website-nextjs/src/components/admin/compare-solvers/SolverSelection.tsx
@@ -163,8 +163,8 @@ const SolverSelection = () => {
           <p className="flex-col gap-1 items-center text-navy text-sm">
             <div className="inline-flex gap-1 items-start">
               <CloseIcon className="size-3 mt-1.5" />
-              represents benchmark instances where at leinteast one of the
-              solvers failed to solve within the time limit, while
+              represents benchmark instances where at least one of the solvers
+              failed to solve within the time limit, while
             </div>
             <div className="flex gap-1 items-center">
               <CircleIcon className="size-3" />


### PR DESCRIPTION
# There is typo
<img width="682" height="506" alt="image" src="https://github.com/user-attachments/assets/e6a2db92-2996-497c-b858-698321317233" />
