### PR TITLE
Benchmarks: add SWITCH-China model with reduced number of load zones

### DIFF
--- a/benchmarks/switch/metadata.yaml
+++ b/benchmarks/switch/metadata.yaml
@@ -1,4 +1,50 @@
 benchmarks:
+  SWITCH-China-open-model-5-loadzones:
+    Short description: A large-scale national energy system model of China built using the SWITCH framework, incorporating extended China-specific modules and updated inputs based on a 2020 base year, with 5 load zones.
+    Modelling framework: SWITCH
+    Model name: SWITCH_China_open_model
+    Version:
+    Contributor(s)/Source: Vamsi Priya Goli, Open Energy Transition; https://github.com/switch-model/switch-china-open-model
+    License: CC BY 4.0
+    Problem class: LP
+    Application: Infrastructure & Capacity expansion
+    Sectoral focus: Power-only
+    Sectors: Electric
+    Time horizon: Multi-stage
+    MILP features: None
+    Sizes:
+    - Name: 5-433ts
+      Size: L
+      URL: https://storage.googleapis.com/solver-benchmarks/instances/SWITCH-China-open-model-5-loadzones-5-433ts.lp.gz
+      Temporal resolution: 433 time slices
+      Spatial resolution: 5 nodes
+      Realistic: true
+      Realistic motivation: Sufficient spatial and temporal resolution over the considered time horizon to allow the benchmark to be defined as Realistic.
+      Num. constraints:
+      Num. variables:
+  SWITCH-China-open-model-10-loadzones:
+    Short description: A large-scale national energy system model of China built using the SWITCH framework, incorporating extended China-specific modules and updated inputs based on a 2020 base year, with 10 load zones.
+    Modelling framework: SWITCH
+    Model name: SWITCH_China_open_model
+    Version:
+    Contributor(s)/Source: Vamsi Priya Goli, Open Energy Transition; https://github.com/switch-model/switch-china-open-model
+    License: CC BY 4.0
+    Problem class: LP
+    Application: Infrastructure & Capacity expansion
+    Sectoral focus: Power-only
+    Sectors: Electric
+    Time horizon: Multi-stage
+    MILP features: None
+    Sizes:
+    - Name: 10-433ts
+      Size: L
+      URL: https://storage.googleapis.com/solver-benchmarks/instances/SWITCH-China-open-model-10-loadzones-10-433ts.lp.gz
+      Temporal resolution: 433 time slices
+      Spatial resolution: 10 nodes
+      Realistic: true
+      Realistic motivation: Sufficient spatial and temporal resolution over the considered time horizon to allow the benchmark to be defined as Realistic.
+      Num. constraints:
+      Num. variables:
   SWITCH-China-open-model-15-loadzones:
     Short description: A large-scale national energy system model of China built using the SWITCH framework, incorporating extended China-specific modules and updated inputs based on a 2020 base year, with 15 load zones.
     Modelling framework: SWITCH

--- a/results/metadata.yaml
+++ b/results/metadata.yaml
@@ -2943,6 +2943,58 @@ benchmarks:
       Num. variables: 131278
       Num. continuous variables: 122017
       Num. integer variables: 9261
+  SWITCH-China-open-model-5-loadzones:
+    Short description: A large-scale national energy system model of China built using
+      the SWITCH framework, incorporating extended China-specific modules and updated
+      inputs based on a 2020 base year, with 5 load zones.
+    Modelling framework: SWITCH
+    Model name: SWITCH_China_open_model
+    Version:
+    Contributor(s)/Source: Vamsi Priya Goli, Open Energy Transition; https://github.com/switch-model/switch-china-open-model
+    License: CC BY 4.0
+    Problem class: LP
+    Application: Infrastructure & Capacity expansion
+    Sectoral focus: Power-only
+    Sectors: Electric
+    Time horizon: Multi-stage
+    MILP features: None
+    Sizes:
+    - Name: 5-433ts
+      Size: L
+      URL: https://storage.googleapis.com/solver-benchmarks/instances/SWITCH-China-open-model-5-loadzones-5-433ts.lp.gz
+      Temporal resolution: 433 time slices
+      Spatial resolution: 5 nodes
+      Realistic: true
+      Realistic motivation: Sufficient spatial and temporal resolution over the considered
+        time horizon to allow the benchmark to be defined as Realistic.
+      Num. constraints:
+      Num. variables:
+  SWITCH-China-open-model-10-loadzones:
+    Short description: A large-scale national energy system model of China built using
+      the SWITCH framework, incorporating extended China-specific modules and updated
+      inputs based on a 2020 base year, with 10 load zones.
+    Modelling framework: SWITCH
+    Model name: SWITCH_China_open_model
+    Version:
+    Contributor(s)/Source: Vamsi Priya Goli, Open Energy Transition; https://github.com/switch-model/switch-china-open-model
+    License: CC BY 4.0
+    Problem class: LP
+    Application: Infrastructure & Capacity expansion
+    Sectoral focus: Power-only
+    Sectors: Electric
+    Time horizon: Multi-stage
+    MILP features: None
+    Sizes:
+    - Name: 10-433ts
+      Size: L
+      URL: https://storage.googleapis.com/solver-benchmarks/instances/SWITCH-China-open-model-10-loadzones-10-433ts.lp.gz
+      Temporal resolution: 433 time slices
+      Spatial resolution: 10 nodes
+      Realistic: true
+      Realistic motivation: Sufficient spatial and temporal resolution over the considered
+        time horizon to allow the benchmark to be defined as Realistic.
+      Num. constraints:
+      Num. variables:
   SWITCH-China-open-model-15-loadzones:
     Short description: A large-scale national energy system model of China built using
       the SWITCH framework, incorporating extended China-specific modules and updated


### PR DESCRIPTION
This PR contains benchmark function for the SWITCH-China model with the reduced number of load zones.

### Checklist

**For PRs adding new benchmark instances:**
- [x] I consent to releasing these benchmark instance files under the CC BY 4.0 license
- [x] The benchmark name and size instance name follow the conventions indicated in the template
- [ ] I have tested that this model instance can be solved to optimality in [time] with [solver] solver, using [options], on a [spec] machine <!-- please indicate which solver, how much RAM memory your machine has, and what solver options were used -->

For Benchmark team:
- [ ] Upload the LP/MPS files (compressed using `gzip -9 <filename>`) to our GCS bucket
- [ ] Run `benchmarks/categorize_benchmarks.py` on them to obtain problem stats and size category
- [ ] Run `tests/validate_urls.py` to ensure URLs are consistent with benchmark and size instance name
- [ ] Test that some solver solves these benchmarks within our timeouts on our infra
