### PR TITLE
Update d3 solver evolution chart to display dynamic maximum benchmarks

### DIFF
--- a/website-nextjs/src/components/shared/D3SolverEvolutionChart.tsx
+++ b/website-nextjs/src/components/shared/D3SolverEvolutionChart.tsx
@@ -319,7 +319,7 @@ const D3SolverEvolutionChart = ({
       .attr("fill", "#43BF94")
       .attr("font-size", "12px")
       .attr("font-weight", "bold")
-      .text(`Max: 105`);
+      .text(`Max: ${totalBenchmarks}`);
 
     return () => {
       tooltip.remove();


### PR DESCRIPTION
**For changes to the website:**
- [x] I have tested my changes by running the website locally

- Update D3SolverEvolutionChart to display dynamic maximum benchmarks

<img width="1054" height="636" alt="image" src="https://github.com/user-attachments/assets/f84ee1d9-a62a-4506-8f38-694e6023398c" />
