### PR TITLE
Benchmarks: Fix IESA-OPT metadata and add openTEPES benchmark

### DIFF
--- a/benchmarks/iesa-opt/metadata.yaml
+++ b/benchmarks/iesa-opt/metadata.yaml
@@ -24,6 +24,7 @@ benchmarks:
       Realistic motivation: Designed for long-term energy planning and policy advice
       Num. constraints: 793714
       Num. variables: 493813
+      Num. nonzeros: 4114762
     - Name: 1-1h
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/instances/IESA-Opt-NL-1-1h.mps.gz
@@ -33,6 +34,7 @@ benchmarks:
       Realistic motivation: Designed for long-term energy planning and policy advice
       Num. constraints: 1967554
       Num. variables: 1107013
+      Num. nonzeros: 11011671
     - Name: 10-1h
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/instances/IESA-Opt-NL-10-1h.mps.gz
@@ -42,6 +44,7 @@ benchmarks:
       Realistic motivation: Designed for long-term energy planning and policy advice
       Num. constraints: 15230366
       Num. variables: 9661524
+      Num. nonzeros: 76484517
     - Name: 5-3h
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/instances/IESA-Opt-NL-5-3h.mps.gz
@@ -51,6 +54,7 @@ benchmarks:
       Realistic motivation: Designed for long-term energy planning and policy advice
       Num. constraints: 15025409
       Num. variables: 12077880
+      Num. nonzeros: 61521715
     - Name: 10-3h
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/instances/IESA-Opt-NL-10-3h.mps.gz
@@ -60,6 +64,7 @@ benchmarks:
       Realistic motivation: Designed for long-term energy planning and policy advice
       Num. constraints: 7603326
       Num. variables: 5672804
+      Num. nonzeros: 33382648
     - Name: 20-3h
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/instances/IESA-Opt-NL-20-3h.mps.gz
@@ -69,6 +74,7 @@ benchmarks:
       Realistic motivation: Designed for long-term energy planning and policy advice
       Num. constraints: 24282926
       Num. variables: 20319294
+      Num. nonzeros: 94953769
     - Name: 25-3h
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/instances/IESA-Opt-NL-25-3h.mps.gz
@@ -78,3 +84,4 @@ benchmarks:
       Realistic motivation: Designed for long-term energy planning and policy advice
       Num. constraints: 35769573
       Num. variables: 30798564
+      Num. nonzeros: 134955169

--- a/benchmarks/opentepes/README.md
+++ b/benchmarks/opentepes/README.md
@@ -1,0 +1,14 @@
+# Generating LP files from optimization problems setup for openTEPES
+
+The **Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES)** has been developed at the [Instituto de Investigación Tecnológica (IIT)](https://www.iit.comillas.edu/index.php.en) of the [Universidad Pontificia Comilla](https://www.comillas.edu/en/>).
+
+The **openTEPES** model presents a decision support system for defining the **integrated generation, storage, and transmission resource planning** (IRP, GEP+SEP+TEP) -**Capacity Expansion Planning** (CEP) or **Integrated Resource Planning** (IRP)- of a **large-scale electric system** at a tactical level (i.e., time horizons of 5-30 years),
+defined as a set of **generation, storage, and (electricity, hydrogen, and heat) networks dynamic investment decisions for multiple future years**. It is a tool for energy system planners for supporting the energy transition towards a **decarbonized, reliable, and affordable energy system**.
+
+The [openTEPES complete documentation](https://opentepes.readthedocs.io/en/latest/index.html) presents the input data, output results, mathematical formulation, download and installation, and the research projects where the model has been used.
+
+To create the MPS file for an optimization problem from openTEPES, you can follow these steps:
+
+- install openTEPES as a Python library using ``pip install opentepes`` or by cloning the repository from GitHub (https://github.com/IIT-EnergySystemModels/openTEPES) and installing it locally.
+- modify the ``openTEPES_ProblemSolving.py`` module to select the MPS format of the output file by substituting the string ``openTEPES_{CaseName}_{p}_{sc}_{st}.lp`` with ``openTEPES_{CaseName}_{p}_{sc}_{st}.mps``. This will create a MPS file with no symbolic labels for the variables and constraints.
+- run the case study selecting the fifth option ``Would you like to write log information (seconds and rows) to console?`` to ``Yes`` to crete the MPS file in the case folder.

--- a/benchmarks/opentepes/metadata.yaml
+++ b/benchmarks/opentepes/metadata.yaml
@@ -1,6 +1,6 @@
 # https://github.com/IIT-EnergySystemModels/openTEPES
 benchmarks:
-  openTEPES-spain_portugal:
+  openTEPES-spain_portugal-elec-uc:
     Short description: Iberian electricity system model with a detailed representation of a hydro basin and unit commitment on hydro generators.
     Modelling framework: openTEPES
     Model name: openTEPES-Spain/Portugal
@@ -15,7 +15,7 @@ benchmarks:
     MILP features: Unit commitment
     Sizes:
     - Name: 8-2h
-      URL: https://storage.googleapis.com/solver-benchmarks/instances/openTEPES-spain_portugal-elec-uc-8_2h.mps.gz
+      URL: https://storage.googleapis.com/solver-benchmarks/instances/openTEPES-spain_portugal-elec-uc-8-2h.mps.gz
       Temporal resolution: 2 hours
       Spatial resolution: 8 nodes
       Realistic: true

--- a/benchmarks/opentepes/metadata.yaml
+++ b/benchmarks/opentepes/metadata.yaml
@@ -1,0 +1,28 @@
+# https://github.com/IIT-EnergySystemModels/openTEPES
+benchmarks:
+  openTEPES-spain_portugal:
+    Short description: Iberian electricity system model with a detailed representation of a hydro basin and unit commitment on hydro generators.
+    Modelling framework: openTEPES
+    Model name: openTEPES-Spain/Portugal
+    Version:
+    Contributor(s)/Source: Andres Ramos, [Universidad Pontificia Comillas](https://pascua.iit.comillas.edu/aramos/Ramos_CV.htm)
+    License: CC BY 4.0
+    Problem class: MILP
+    Application: Operational
+    Sectoral focus: Power-only
+    Sectors: Electric
+    Time horizon: Single period (2025)
+    MILP features: Unit commitment
+    Sizes:
+    - Name: 8-2h
+      URL: https://storage.googleapis.com/solver-benchmarks/instances/openTEPES-spain_portugal-elec-uc-8_2h.mps
+      Temporal resolution: 2 hours
+      Spatial resolution: 8 nodes
+      Realistic: true
+      Realistic motivation: Used in the national research project "Hydro generation advanced systems modeling, control, and optimized integration to the system (AVANHID)", developed for the Ministry of Science and Innovation/State Research Agency (MICIN/AEI/10.13039/501100011033) under the program Public-Private Partnerships with NextGenerationEU/PRTR funds (CPP2021-009114). October 2022 - November 2025.
+      Size: L
+      Num. constraints: 1727170
+      Num. variables: 2913989
+      Num. nonzeros: 7860707
+      Num. continuous variables: 2193272
+      Num. integer variables: 720717

--- a/benchmarks/opentepes/metadata.yaml
+++ b/benchmarks/opentepes/metadata.yaml
@@ -15,7 +15,7 @@ benchmarks:
     MILP features: Unit commitment
     Sizes:
     - Name: 8-2h
-      URL: https://storage.googleapis.com/solver-benchmarks/instances/openTEPES-spain_portugal-elec-uc-8_2h.mps
+      URL: https://storage.googleapis.com/solver-benchmarks/instances/openTEPES-spain_portugal-elec-uc-8_2h.mps.gz
       Temporal resolution: 2 hours
       Spatial resolution: 8 nodes
       Realistic: true

--- a/results/metadata.yaml
+++ b/results/metadata.yaml
@@ -674,6 +674,7 @@ benchmarks:
       Realistic motivation: Designed for long-term energy planning and policy advice
       Num. constraints: 793714
       Num. variables: 493813
+      Num. nonzeros: 4114762
     - Name: 1-1h
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/instances/IESA-Opt-NL-1-1h.mps.gz
@@ -683,6 +684,7 @@ benchmarks:
       Realistic motivation: Designed for long-term energy planning and policy advice
       Num. constraints: 1967554
       Num. variables: 1107013
+      Num. nonzeros: 11011671
     - Name: 10-1h
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/instances/IESA-Opt-NL-10-1h.mps.gz
@@ -692,6 +694,7 @@ benchmarks:
       Realistic motivation: Designed for long-term energy planning and policy advice
       Num. constraints: 15230366
       Num. variables: 9661524
+      Num. nonzeros: 76484517
     - Name: 5-3h
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/instances/IESA-Opt-NL-5-3h.mps.gz
@@ -701,6 +704,7 @@ benchmarks:
       Realistic motivation: Designed for long-term energy planning and policy advice
       Num. constraints: 15025409
       Num. variables: 12077880
+      Num. nonzeros: 61521715
     - Name: 10-3h
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/instances/IESA-Opt-NL-10-3h.mps.gz
@@ -710,6 +714,7 @@ benchmarks:
       Realistic motivation: Designed for long-term energy planning and policy advice
       Num. constraints: 7603326
       Num. variables: 5672804
+      Num. nonzeros: 33382648
     - Name: 20-3h
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/instances/IESA-Opt-NL-20-3h.mps.gz
@@ -719,6 +724,7 @@ benchmarks:
       Realistic motivation: Designed for long-term energy planning and policy advice
       Num. constraints: 24282926
       Num. variables: 20319294
+      Num. nonzeros: 94953769
     - Name: 25-3h
       Size: L
       URL: https://storage.googleapis.com/solver-benchmarks/instances/IESA-Opt-NL-25-3h.mps.gz
@@ -728,6 +734,7 @@ benchmarks:
       Realistic motivation: Designed for long-term energy planning and policy advice
       Num. constraints: 35769573
       Num. variables: 30798564
+      Num. nonzeros: 134955169
   genx-1_three_zones:
     Short description: Three Zones, a one-year example with hourly resolution, contains
       zones representing Massachusetts, Connecticut, and Maine. The ten represented
@@ -2493,6 +2500,38 @@ benchmarks:
       Num. constraints: 78851
       Num. variables: 78851
       Num. nonzeros: 214320
+  openTEPES-spain_portugal:
+    Short description: Iberian electricity system model with a detailed representation
+      of a hydro basin and unit commitment on hydro generators.
+    Modelling framework: openTEPES
+    Model name: openTEPES-Spain/Portugal
+    Version:
+    Contributor(s)/Source: Andres Ramos, [Universidad Pontificia Comillas](https://pascua.iit.comillas.edu/aramos/Ramos_CV.htm)
+    License: CC BY 4.0
+    Problem class: MILP
+    Application: Operational
+    Sectoral focus: Power-only
+    Sectors: Electric
+    Time horizon: Single period (2025)
+    MILP features: Unit commitment
+    Sizes:
+    - Name: 8-2h
+      URL: https://storage.googleapis.com/solver-benchmarks/instances/openTEPES-spain_portugal-elec-uc-8_2h.mps
+      Temporal resolution: 2 hours
+      Spatial resolution: 8 nodes
+      Realistic: true
+      Realistic motivation: Used in the national research project "Hydro generation
+        advanced systems modeling, control, and optimized integration to the system
+        (AVANHID)", developed for the Ministry of Science and Innovation/State Research
+        Agency (MICIN/AEI/10.13039/501100011033) under the program Public-Private
+        Partnerships with NextGenerationEU/PRTR funds (CPP2021-009114). October 2022
+        - November 2025.
+      Size: L
+      Num. constraints: 1727170
+      Num. variables: 2913989
+      Num. nonzeros: 7860707
+      Num. continuous variables: 2193272
+      Num. integer variables: 720717
   pypsa-power+ely:
     Short description: Simple PyPSA-based single-node gas + wind + solar + electrolyzer
       infrastructure model for a single year-time horizon.

--- a/results/metadata.yaml
+++ b/results/metadata.yaml
@@ -2500,7 +2500,7 @@ benchmarks:
       Num. constraints: 78851
       Num. variables: 78851
       Num. nonzeros: 214320
-  openTEPES-spain_portugal:
+  openTEPES-spain_portugal-elec-uc:
     Short description: Iberian electricity system model with a detailed representation
       of a hydro basin and unit commitment on hydro generators.
     Modelling framework: openTEPES
@@ -2516,7 +2516,7 @@ benchmarks:
     MILP features: Unit commitment
     Sizes:
     - Name: 8-2h
-      URL: https://storage.googleapis.com/solver-benchmarks/instances/openTEPES-spain_portugal-elec-uc-8_2h.mps
+      URL: https://storage.googleapis.com/solver-benchmarks/instances/openTEPES-spain_portugal-elec-uc-8-2h.mps.gz
       Temporal resolution: 2 hours
       Spatial resolution: 8 nodes
       Realistic: true

--- a/website/src/data/benchmarkModelCasesData.ts
+++ b/website/src/data/benchmarkModelCasesData.ts
@@ -12,6 +12,7 @@ export interface IBenchmarkModelCases {
   TIMES: string;
   Tulipa: string;
   "ZEN-garden": string;
+  OpenTEPES: string;
   [key: string]: string;
 }
 
@@ -30,6 +31,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "",
     Tulipa: "",
     "ZEN-garden": "",
+    OpenTEPES: "",
   },
   {
     header: "LP",
@@ -45,6 +47,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "true",
     Tulipa: "false",
     "ZEN-garden": "true",
+    OpenTEPES: "false",
   },
   {
     header: "MILP",
@@ -60,6 +63,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "true",
     "ZEN-garden": "false",
+    OpenTEPES: "true",
   },
   {
     header: "Applications",
@@ -75,6 +79,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "",
     Tulipa: "",
     "ZEN-garden": "",
+    OpenTEPES: "",
   },
 
   {
@@ -91,6 +96,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "true",
     Tulipa: "false",
     "ZEN-garden": "true",
+    OpenTEPES: "false",
   },
   {
     header: "Operational",
@@ -106,6 +112,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
+    OpenTEPES: "true",
   },
   {
     header: "Production cost modelling",
@@ -121,6 +128,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
+    OpenTEPES: "false",
   },
   {
     header: "DC Optimal Power Flow",
@@ -136,6 +144,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
+    OpenTEPES: "false",
   },
   {
     header: "Steady-state Optimal Power Flow",
@@ -151,6 +160,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
+    OpenTEPES: "false",
   },
   {
     header: "Resource Adequacy",
@@ -166,6 +176,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
+    OpenTEPES: "false",
   },
   {
     header: "MILP Features",
@@ -181,6 +192,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "",
     Tulipa: "",
     "ZEN-garden": "",
+    OpenTEPES: "",
   },
   {
     header: "None",
@@ -196,6 +208,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "true",
     Tulipa: "false",
     "ZEN-garden": "true",
+    OpenTEPES: "false",
   },
   {
     header: "Unit commitment",
@@ -211,6 +224,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "true",
     "ZEN-garden": "false",
+    OpenTEPES: "true",
   },
   {
     header: "Transmission switching",
@@ -226,6 +240,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
+    OpenTEPES: "false",
   },
   {
     header: "Modularity",
@@ -241,6 +256,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "true",
     "ZEN-garden": "false",
+    OpenTEPES: "false",
   },
   {
     header: "Binary transmission investment decisions",
@@ -256,6 +272,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
+    OpenTEPES: "false",
   },
   {
     header: "Piecewise fuel usage",
@@ -271,6 +288,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
+    OpenTEPES: "false",
   },
   {
     header: "Piecewise-linear part-load efficiency modeling",
@@ -286,6 +304,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
+    OpenTEPES: "false",
   },
   {
     header: "Piecewise efficiency",
@@ -301,6 +320,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
+    OpenTEPES: "false",
   },
   {
     header: "Modelling of fixed costs",
@@ -316,6 +336,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
+    OpenTEPES: "false",
   },
   {
     header: "NonConvex operation",
@@ -331,6 +352,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
+    OpenTEPES: "false",
   },
   {
     header: "Realistic",
@@ -346,6 +368,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "",
     Tulipa: "",
     "ZEN-garden": "",
+    OpenTEPES: "",
   },
   {
     header: "Realistic",
@@ -361,5 +384,6 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "true",
     Tulipa: "true",
     "ZEN-garden": "true",
+    OpenTEPES: "true",
   },
 ];

--- a/website/src/data/benchmarkModelCasesData.ts
+++ b/website/src/data/benchmarkModelCasesData.ts
@@ -12,7 +12,7 @@ export interface IBenchmarkModelCases {
   TIMES: string;
   Tulipa: string;
   "ZEN-garden": string;
-  OpenTEPES: string;
+  openTePES: string;
   [key: string]: string;
 }
 
@@ -31,7 +31,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "",
     Tulipa: "",
     "ZEN-garden": "",
-    OpenTEPES: "",
+    openTePES: "",
   },
   {
     header: "LP",
@@ -47,7 +47,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "true",
     Tulipa: "false",
     "ZEN-garden": "true",
-    OpenTEPES: "false",
+    openTePES: "false",
   },
   {
     header: "MILP",
@@ -63,7 +63,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "true",
     "ZEN-garden": "false",
-    OpenTEPES: "true",
+    openTePES: "true",
   },
   {
     header: "Applications",
@@ -79,7 +79,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "",
     Tulipa: "",
     "ZEN-garden": "",
-    OpenTEPES: "",
+    openTePES: "",
   },
 
   {
@@ -96,7 +96,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "true",
     Tulipa: "false",
     "ZEN-garden": "true",
-    OpenTEPES: "false",
+    openTePES: "false",
   },
   {
     header: "Operational",
@@ -112,7 +112,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
-    OpenTEPES: "true",
+    openTePES: "true",
   },
   {
     header: "Production cost modelling",
@@ -128,7 +128,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
-    OpenTEPES: "false",
+    openTePES: "false",
   },
   {
     header: "DC Optimal Power Flow",
@@ -144,7 +144,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
-    OpenTEPES: "false",
+    openTePES: "false",
   },
   {
     header: "Steady-state Optimal Power Flow",
@@ -160,7 +160,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
-    OpenTEPES: "false",
+    openTePES: "false",
   },
   {
     header: "Resource Adequacy",
@@ -176,7 +176,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
-    OpenTEPES: "false",
+    openTePES: "false",
   },
   {
     header: "MILP Features",
@@ -192,7 +192,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "",
     Tulipa: "",
     "ZEN-garden": "",
-    OpenTEPES: "",
+    openTePES: "",
   },
   {
     header: "None",
@@ -208,7 +208,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "true",
     Tulipa: "false",
     "ZEN-garden": "true",
-    OpenTEPES: "false",
+    openTePES: "false",
   },
   {
     header: "Unit commitment",
@@ -224,7 +224,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "true",
     "ZEN-garden": "false",
-    OpenTEPES: "true",
+    openTePES: "true",
   },
   {
     header: "Transmission switching",
@@ -240,7 +240,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
-    OpenTEPES: "false",
+    openTePES: "false",
   },
   {
     header: "Modularity",
@@ -256,7 +256,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "true",
     "ZEN-garden": "false",
-    OpenTEPES: "false",
+    openTePES: "false",
   },
   {
     header: "Binary transmission investment decisions",
@@ -272,7 +272,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
-    OpenTEPES: "false",
+    openTePES: "false",
   },
   {
     header: "Piecewise fuel usage",
@@ -288,7 +288,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
-    OpenTEPES: "false",
+    openTePES: "false",
   },
   {
     header: "Piecewise-linear part-load efficiency modeling",
@@ -304,7 +304,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
-    OpenTEPES: "false",
+    openTePES: "false",
   },
   {
     header: "Piecewise efficiency",
@@ -320,7 +320,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
-    OpenTEPES: "false",
+    openTePES: "false",
   },
   {
     header: "Modelling of fixed costs",
@@ -336,7 +336,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
-    OpenTEPES: "false",
+    openTePES: "false",
   },
   {
     header: "NonConvex operation",
@@ -352,7 +352,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "false",
     Tulipa: "false",
     "ZEN-garden": "false",
-    OpenTEPES: "false",
+    openTePES: "false",
   },
   {
     header: "Realistic",
@@ -368,7 +368,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "",
     Tulipa: "",
     "ZEN-garden": "",
-    OpenTEPES: "",
+    openTePES: "",
   },
   {
     header: "Realistic",
@@ -384,6 +384,6 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     TIMES: "true",
     Tulipa: "true",
     "ZEN-garden": "true",
-    OpenTEPES: "true",
+    openTePES: "true",
   },
 ];


### PR DESCRIPTION
### Benchmark contributions

This PR builds on #436 by @arght to add the proposed OpenTEPES benchmark (opening a new PR eases fixing the metadata content to follow the standards of the repository).

### Checklist

**For PRs adding new benchmark instances:**
- [x] I consent to releasing these benchmark instance files under the CC BY 4.0 license
- [x] The benchmark name and size instance name follow the conventions indicated in the template
- [x] I have tested that this model instance can be solved to optimality in 51986.80 s with Gurobi solver, using default options, on a 62 GB machine (#436 reports 1860 s with Gurobi solver, using method 2, on a Windows 11; 8 AMD64 Family 25 Model 117 Stepping 2, AuthenticAMD physical cores at 3.19 GHz; 31.3 GB machine)

For Benchmark team:
- [x] Upload the LP/MPS files (compressed using `gzip -9 <filename>`) to our GCS bucket
- [x] Run `benchmarks/categorize_benchmarks.py` on them to obtain problem stats and size category
- [x] Run `tests/validate_urls.py` to ensure URLs are consistent with benchmark and size instance name
- [x] Update the summary table in the Key Insights page (if the proposed benchmark(s) is/are adding any new features)
- [ ] Test that some solver solves these benchmarks within our timeouts on our infra
- [x] Add CC BY 4.0 license to the metadata file