### PR TITLE
Fix summary table

### DIFF
--- a/website/src/data/benchmarkModelCasesData.ts
+++ b/website/src/data/benchmarkModelCasesData.ts
@@ -211,7 +211,7 @@ export const benchmarkModelCasesData: IBenchmarkModelCases[] = [
     PowerModels: "",
     PyPSA: "",
     Sienna: "",
-    SpineOpt: "false",
+    SpineOpt: "",
     SWITCH: "",
     TEMOA: "",
     TIMES: "",


### PR DESCRIPTION
This PR fixes the summary table in the Key Insights page showing "MILP features" in bold format. 

**For changes to the website:**
- [x] I have tested my changes by running the website locally
