### PR TITLE
Improve tag stripping for TOC label extraction

### DIFF
--- a/website/src/pages/blog/[slug].tsx
+++ b/website/src/pages/blog/[slug].tsx
@@ -26,11 +26,17 @@ type Props = {
 };
 
 function slugify(text: string) {
+  let sanitized = text;
+  let previous: string;
+  do {
+    previous = sanitized;
+    sanitized = sanitized.replace(/<[^>]*>/g, "");
+  } while (sanitized !== previous);
+
   return (
-    text
+    sanitized
       .toLowerCase()
       .trim()
-      .replace(/<[^>]*>/g, "")
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-+|-+$/g, "") || "section"
   );
@@ -42,7 +48,10 @@ function extractTocAndInjectIds(htmlString: string) {
   const newHtml = htmlString.replace(
     /<h2([^>]*)>(.*?)<\/h2>/gi,
     (match, attrs = "", inner) => {
-      const label = inner.replace(/<[^>]+>/g, "").trim();
+      const label = inner
+        .replace(/<[^>]*>/g, "") // remove complete tags
+        .replace(/<[^>]*/g, "") // remove unclosed tags (e.g. <script without >)
+        .trim();
       const slug = slugify(label);
       const hash = `#${slug}`;
       toc.push({ hash, label });


### PR DESCRIPTION
fixes: (https://github.com/open-energy-transition/solver-benchmark/security/code-scanning/2

**For changes to the website:**
- [x] I have tested my changes by running the website locally
