### PR TITLE
Implement responsive card layout for mobile in key-insight

### DIFF
--- a/website/src/components/admin/benchmarks/BenchmarkSummaryTable.tsx
+++ b/website/src/components/admin/benchmarks/BenchmarkSummaryTable.tsx
@@ -139,7 +139,8 @@ const BenchmarkSummaryTable = () => {
   return (
     <div className="bg-[#F4F6FA] p-4 px-0 rounded-xl mb-6 space-y-8 w-full">
       <div>
-        <div className="overflow-x-auto" tabIndex={0}>
+        {/* Desktop/tablet table */}
+        <div className="hidden md:block overflow-x-auto" tabIndex={0}>
           <table className="min-w-full  -gray-200">
             <thead>
               <tr className="bg-[#F4F6FA]">
@@ -366,6 +367,301 @@ const BenchmarkSummaryTable = () => {
               ))}
             </tbody>
           </table>
+        </div>
+
+        {/* Mobile card layout — vertical key/value, no horizontal scroll */}
+        <div className="md:hidden space-y-4">
+          {/* N. of Problems */}
+          <div className="bg-white rounded-xl p-4 shadow-sm">
+            <h3 className="tag-line-xs font-extrabold mb-3">N. of Problems</h3>
+            {nOfProblems.map((label, idx) => {
+              const total =
+                idx === 0
+                  ? summary.reduce(
+                      (acc, curr) =>
+                        acc +
+                        (curr.nOfProblems.get("totalNOfDiffProblems") || 0),
+                      0,
+                    )
+                  : summary.reduce(
+                      (acc, curr) =>
+                        acc + (curr.nOfProblems.get("multipleSizes") || 0),
+                      0,
+                    );
+              return (
+                <div
+                  key={idx}
+                  className={
+                    idx > 0 ? "mt-4 pt-4 border-t border-gray-100" : ""
+                  }
+                >
+                  <p className="tag-line-sm font-semibold mb-2">{label}</p>
+                  <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+                    {summary.map((s, sIdx) => (
+                      <div
+                        key={sIdx}
+                        className="flex justify-between items-center py-0.5"
+                      >
+                        <span className="tag-line-xs text-navy text-opacity-60 truncate pr-2">
+                          {s.modellingFramework}
+                        </span>
+                        <span className="tag-line-xs font-medium shrink-0">
+                          {idx === 0
+                            ? s.nOfProblems.get("totalNOfDiffProblems") || 0
+                            : s.nOfProblems.get("multipleSizes")}
+                        </span>
+                      </div>
+                    ))}
+                    <div className="col-span-2 flex justify-between items-center pt-1.5 mt-0.5 border-t border-gray-200">
+                      <span className="tag-line-xs font-extrabold">Total</span>
+                      <span className="tag-line-xs font-extrabold">
+                        {total}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Problem Class */}
+          <div className="bg-white rounded-xl p-4 shadow-sm">
+            <h3 className="tag-line-xs font-extrabold mb-3">Problem Class</h3>
+            {availableProblemClasses.map((problemClass, idx) => {
+              const total = summary.reduce(
+                (acc, curr) =>
+                  acc + (curr.problemClasses.get(problemClass) || 0),
+                0,
+              );
+              return (
+                <div
+                  key={idx}
+                  className={
+                    idx > 0 ? "mt-4 pt-4 border-t border-gray-100" : ""
+                  }
+                >
+                  <p className="tag-line-sm font-semibold mb-2">
+                    {problemClass}
+                  </p>
+                  <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+                    {summary.map((s, sIdx) => (
+                      <div
+                        key={sIdx}
+                        className="flex justify-between items-center py-0.5"
+                      >
+                        <span className="tag-line-xs text-navy text-opacity-60 truncate pr-2">
+                          {s.modellingFramework}
+                        </span>
+                        <span className="tag-line-xs font-medium shrink-0">
+                          {s.problemClasses.get(problemClass) || 0}
+                        </span>
+                      </div>
+                    ))}
+                    <div className="col-span-2 flex justify-between items-center pt-1.5 mt-0.5 border-t border-gray-200">
+                      <span className="tag-line-xs font-extrabold">Total</span>
+                      <span className="tag-line-xs font-extrabold">
+                        {total}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Application */}
+          <div className="bg-white rounded-xl p-4 shadow-sm">
+            <h3 className="tag-line-xs font-extrabold mb-3">Application</h3>
+            {availableApplications.map((application, idx) => {
+              const total = summary.reduce(
+                (acc, curr) => acc + (curr.applications.get(application) || 0),
+                0,
+              );
+              return (
+                <div
+                  key={idx}
+                  className={
+                    idx > 0 ? "mt-4 pt-4 border-t border-gray-100" : ""
+                  }
+                >
+                  <p className="tag-line-sm font-semibold mb-2">
+                    {application}
+                  </p>
+                  <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+                    {summary.map((s, sIdx) => (
+                      <div
+                        key={sIdx}
+                        className="flex justify-between items-center py-0.5"
+                      >
+                        <span className="tag-line-xs text-navy text-opacity-60 truncate pr-2">
+                          {s.modellingFramework}
+                        </span>
+                        <span className="tag-line-xs font-medium shrink-0">
+                          {s.applications.get(application) || 0}
+                        </span>
+                      </div>
+                    ))}
+                    <div className="col-span-2 flex justify-between items-center pt-1.5 mt-0.5 border-t border-gray-200">
+                      <span className="tag-line-xs font-extrabold">Total</span>
+                      <span className="tag-line-xs font-extrabold">
+                        {total}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Time Horizon */}
+          <div className="bg-white rounded-xl p-4 shadow-sm">
+            <h3 className="tag-line-xs font-extrabold mb-3">Time Horizon</h3>
+            {availabletimeHorizons.map((timeHorizon, idx) => {
+              const total = summary.reduce((acc, curr) => {
+                const a = acc == -1 ? 0 : acc || 0;
+                const b =
+                  curr.timeHorizons.get(timeHorizon) == -1
+                    ? 0
+                    : curr.timeHorizons.get(timeHorizon) || 0;
+                return a + b;
+              }, 0);
+              return (
+                <div
+                  key={idx}
+                  className={
+                    idx > 0 ? "mt-4 pt-4 border-t border-gray-100" : ""
+                  }
+                >
+                  <p className="tag-line-sm font-semibold mb-2">
+                    {getTimeHorizonLabel(timeHorizon)}
+                  </p>
+                  <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+                    {summary.map((s, sIdx) => (
+                      <div
+                        key={sIdx}
+                        className="flex justify-between items-center py-0.5"
+                      >
+                        <span className="tag-line-xs text-navy text-opacity-60 truncate pr-2">
+                          {s.modellingFramework}
+                        </span>
+                        <span className="tag-line-xs font-medium shrink-0">
+                          {s.timeHorizons.get(timeHorizon) == -1
+                            ? "N/A"
+                            : s.timeHorizons.get(timeHorizon) || 0}
+                        </span>
+                      </div>
+                    ))}
+                    <div className="col-span-2 flex justify-between items-center pt-1.5 mt-0.5 border-t border-gray-200">
+                      <span className="tag-line-xs font-extrabold">Total</span>
+                      <span className="tag-line-xs font-extrabold">
+                        {total}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* MILP Features */}
+          <div className="bg-white rounded-xl p-4 shadow-sm">
+            <h3 className="tag-line-xs font-extrabold mb-3">MILP Features</h3>
+            {availableMilpFeatures.map((milpFeature, idx) => {
+              const total = summary.reduce(
+                (acc, curr) =>
+                  acc + (curr.milpFeatures.get(milpFeature as string) || 0),
+                0,
+              );
+              return (
+                <div
+                  key={idx}
+                  className={
+                    idx > 0 ? "mt-4 pt-4 border-t border-gray-100" : ""
+                  }
+                >
+                  <p className="tag-line-sm font-semibold mb-2">
+                    {milpFeature || "-"}
+                  </p>
+                  <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+                    {summary.map((s, sIdx) => (
+                      <div
+                        key={sIdx}
+                        className="flex justify-between items-center py-0.5"
+                      >
+                        <span className="tag-line-xs text-navy text-opacity-60 truncate pr-2">
+                          {s.modellingFramework}
+                        </span>
+                        <span className="tag-line-xs font-medium shrink-0">
+                          {s.milpFeatures.get(milpFeature as string) || 0}
+                        </span>
+                      </div>
+                    ))}
+                    <div className="col-span-2 flex justify-between items-center pt-1.5 mt-0.5 border-t border-gray-200">
+                      <span className="tag-line-xs font-extrabold">Total</span>
+                      <span className="tag-line-xs font-extrabold">
+                        {total}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Realistic */}
+          <div className="bg-white rounded-xl p-4 shadow-sm">
+            <h3 className="tag-line-xs font-extrabold mb-3">Realistic</h3>
+            {(["Real (MILP)", "Other"] as const).map((size, idx) => {
+              const total =
+                size === "Other"
+                  ? summary.reduce(
+                      (acc, curr) => acc + (curr.realSizes.get("other") || 0),
+                      0,
+                    )
+                  : `${summary.reduce(
+                      (acc, curr) => acc + (curr.realSizes.get("real") || 0),
+                      0,
+                    )} (${summary.reduce(
+                      (acc, curr) => acc + (curr.realSizes.get("milp") || 0),
+                      0,
+                    )})`;
+              return (
+                <div
+                  key={idx}
+                  className={
+                    idx > 0 ? "mt-4 pt-4 border-t border-gray-100" : ""
+                  }
+                >
+                  <p className="tag-line-sm font-semibold mb-2">{size}</p>
+                  <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+                    {summary.map((s, sIdx) => (
+                      <div
+                        key={sIdx}
+                        className="flex justify-between items-center py-0.5"
+                      >
+                        <span className="tag-line-xs text-navy text-opacity-60 truncate pr-2">
+                          {s.modellingFramework}
+                        </span>
+                        <span className="tag-line-xs font-medium shrink-0">
+                          {size === "Other"
+                            ? s.realSizes.get("other") || 0
+                            : `${s.realSizes.get("real") || 0} (${
+                                s.realSizes.get("milp") || 0
+                              })`}
+                        </span>
+                      </div>
+                    ))}
+                    <div className="col-span-2 flex justify-between items-center pt-1.5 mt-0.5 border-t border-gray-200">
+                      <span className="tag-line-xs font-extrabold">Total</span>
+                      <span className="tag-line-xs font-extrabold">
+                        {total}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         </div>
       </div>
     </div>

--- a/website/src/components/key-insights/charts/ProblemClassTable.tsx
+++ b/website/src/components/key-insights/charts/ProblemClassTable.tsx
@@ -254,13 +254,99 @@ const ProblemClassTable = ({ problemClass }: ProblemClassTableProps) => {
 
   return (
     <div className="my-4 mt-8 rounded-xl">
-      <TanStackTable
-        data={modelFrameworkMaxSizeData}
-        columns={columns as any}
-        showPagination={false}
-        rowClassName="tag-line-sm leading-1.4 text-navy text-start p-2 lg:px-6 truncate"
-        headerClassName="text-center text-navy p-2 lg:py-4 lg:px-6 cursor-pointer"
-      />
+      {/* Desktop / tablet: original table */}
+      <div className="hidden md:block">
+        <TanStackTable
+          data={modelFrameworkMaxSizeData}
+          columns={columns as any}
+          showPagination={false}
+          rowClassName="tag-line-sm leading-1.4 text-navy text-start p-2 lg:px-6 truncate"
+          headerClassName="text-center text-navy p-2 lg:py-4 lg:px-6 cursor-pointer"
+        />
+      </div>
+
+      {/* Mobile: card UI per framework */}
+      <div className="md:hidden space-y-4">
+        {modelFrameworkMaxSizeData.map((item: any, idx: number) => {
+          const parts = String(item.problemClass).split(" ");
+          const benchmarkName = parts[0];
+          const sizeName = parts.slice(1).join(" ");
+
+          return (
+            <div
+              key={item.modelName || idx}
+              className="bg-white rounded-xl p-4 shadow-sm"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="font-bold tag-line-sm truncate">
+                    {item.modelName}
+                  </div>
+                  <div className="tag-line-xs text-navy text-opacity-60 mt-1 truncate">
+                    <Link
+                      href={getBenchmarksetLink(item.problemClass)}
+                      className="inline-block"
+                    >
+                      <span className="font-semibold">{benchmarkName}</span>
+                      {sizeName && <span className="ml-1">({sizeName})</span>}
+                    </Link>
+                  </div>
+                </div>
+
+                <div className="text-right shrink-0">
+                  <div className="tag-line-xs font-extrabold">
+                    <br />
+                  </div>
+                  <div className="tag-line-xs text-navy text-opacity-60">
+                    {item.solver}
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1 text-sm">
+                <div className="text-navy text-opacity-60">Runtime</div>
+                <div className="text-right font-medium">
+                  {" "}
+                  {typeof item.runtime === "number"
+                    ? humanizeSeconds(item.runtime)
+                    : item.runtime}
+                </div>
+
+                <div className="text-navy text-opacity-60">Num. variables</div>
+                <div className="text-right font-medium">
+                  {formatNumberWithCommas(item.numVariables)}
+                </div>
+
+                <div className="text-navy text-opacity-60">Num. variables</div>
+                <div className="text-right font-medium">
+                  {formatNumberWithCommas(item.numVariables)}
+                </div>
+
+                <div className="text-navy text-opacity-60">
+                  Num. constraints
+                </div>
+                <div className="text-right font-medium">
+                  {formatNumberWithCommas(item.constraints)}
+                </div>
+
+                <div className="text-navy text-opacity-60">
+                  Spatial resolution
+                </div>
+                <div className="text-right font-medium">
+                  {item.spatialResolution}
+                </div>
+
+                <div className="text-navy text-opacity-60">
+                  Temporal resolution
+                </div>
+                <div className="text-right font-medium">
+                  {item.temporalResolution}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 };

--- a/website/src/components/key-insights/tables/BenchmarkModelCasesTable.tsx
+++ b/website/src/components/key-insights/tables/BenchmarkModelCasesTable.tsx
@@ -87,12 +87,47 @@ const BenchmarkModelCasesTable = () => {
 
   return (
     <div className="my-4 mt-8 rounded-xl">
-      <TanStackTable
-        data={benchmarkModelCasesData}
-        headerClassName="text-center text-navy p-2 cursor-pointer"
-        columns={columns as any}
-        showPagination={false}
-      />
+      {/* Desktop / tablet: original table */}
+      <div className="hidden md:block">
+        <TanStackTable
+          data={benchmarkModelCasesData}
+          headerClassName="text-center text-navy p-2 cursor-pointer"
+          columns={columns as any}
+          showPagination={false}
+        />
+      </div>
+
+      {/* Mobile: show a card per framework to avoid horizontal scroll */}
+      <div className="md:hidden space-y-4">
+        {availableModellingFrameworks.map((framework) => {
+          const key = framework.replaceAll(".", "_");
+          return (
+            <div key={framework} className="bg-white rounded-xl p-4 shadow-sm">
+              <div className="flex items-center justify-between">
+                <div className="font-bold tag-line-sm truncate">
+                  {framework}
+                </div>
+              </div>
+
+              <div className="mt-3 space-y-2">
+                {benchmarkModelCasesData.map((row) => (
+                  <div
+                    key={row.header}
+                    className="flex items-center justify-between"
+                  >
+                    <div className="tag-line-xs text-navy text-opacity-60">
+                      {row.header}
+                    </div>
+                    <div className="ml-2">
+                      {renderModelData((row as any)[key])}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 };

--- a/website/src/components/key-insights/tables/BenchmarkModelInsightsTable.tsx
+++ b/website/src/components/key-insights/tables/BenchmarkModelInsightsTable.tsx
@@ -181,12 +181,67 @@ const BenchmarkModelInsightsTable = () => {
 
   return (
     <div className="my-4 mt-8 rounded-xl">
-      <TanStackTable
-        data={tableData}
-        headerClassName="text-center text-navy p-2 cursor-pointer"
-        columns={columns as any}
-        showPagination={false}
-      />
+      {/* Desktop / tablet: keep table */}
+      <div className="hidden md:block">
+        <TanStackTable
+          data={tableData}
+          headerClassName="text-center text-navy p-2 cursor-pointer"
+          columns={columns as any}
+          showPagination={false}
+        />
+      </div>
+
+      {/* Mobile: card UI per framework */}
+      <div className="md:hidden space-y-4">
+        {tableData.map((item: any, idx: number) => (
+          <div
+            key={`${item.framework}-${idx}`}
+            className="bg-white rounded-xl p-4 shadow-sm"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <div className="font-bold tag-line-sm truncate">
+                  {item.framework}
+                </div>
+                <div className="tag-line-xs text-navy text-opacity-60 mt-1 truncate">
+                  <span className="font-semibold">{item.problemClass}</span>
+                  <span className="mx-1">—</span>
+                  <span>{item.application}</span>
+                </div>
+              </div>
+
+              <div className="text-right shrink-0">
+                <div className="tag-line-xs font-extrabold">
+                  {item.milpFeatures}
+                </div>
+                <div className="tag-line-xs text-navy text-opacity-60 mt-1">
+                  {String(item.realistic) === "Realistic" ? "Yes" : "No"}
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-3">
+              <div className="text-navy text-opacity-60 text-sm">Examples</div>
+              <div className="mt-2 space-y-1">
+                {Array.isArray(item.example) ? (
+                  item.example.map((e: string) => (
+                    <div key={e} className="truncate">
+                      <Link
+                        href={getBenchmarksetLink(e)}
+                        className="font-medium text-navy"
+                      >
+                        {e}
+                      </Link>
+                    </div>
+                  ))
+                ) : (
+                  <div className="font-medium">{String(item.example)}</div>
+                )}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Fixes: Implement responsive card layout for mobile in key-insight

**For changes to the website:**
- [x] I have tested my changes by running the website locally
<img width="447" height="712" alt="image" src="https://github.com/user-attachments/assets/fe972cea-2c9f-4bd1-b0e4-3386d5f4b032" />
