### PR TITLE
Fix categorize_benchmarks.py

### DIFF
--- a/benchmarks/categorize_benchmarks.py
+++ b/benchmarks/categorize_benchmarks.py
@@ -92,19 +92,17 @@ def create_yaml() -> YAML:
 
 def iter_metadata_files(root: Path) -> Iterable[Path]:
     """
-    Yield metadata YAML files under a directory.
-
-    Parameters
-    ----------
-    root : Path
-        Root directory to scan.
-
-    Yields
-    ------
-    Path
-        Paths matching `[Mm]etadata*.yaml`.
+    Yield benchmark metadata YAML files under a directory.
     """
-    yield from sorted(root.rglob("[Mm]etadata*.yaml"))
+    excluded = {
+        "metadata_schema.yaml",
+        "_template_metadata.yaml",
+    }
+
+    for path in sorted(root.rglob("[Mm]etadata*.yaml")):
+        if path.name in excluded:
+            continue
+        yield path
 
 
 def read_text_file(path: Path) -> str:


### PR DESCRIPTION
I noticed that `categorize_benchmarks.py` wasn't filtering benchmark metadata files strictly enough. It was matching every YAML file starting with `metadata`, including `metadata_schema.yaml` and `_template_metadata.yaml`, and then trying to process them as benchmark metadata files. This caused the script to fail on `metadata_schema.yaml`, which is a schema file rather than a benchmark metadata file.