### PR TITLE
fix: mobile layout issues with text overflowing in wrong positions on resize

### DIFF
--- a/website/src/components/landing-page/sections/GetStartedChart.tsx
+++ b/website/src/components/landing-page/sections/GetStartedChart.tsx
@@ -45,7 +45,7 @@ const NOTE_BOX = (
   </div>
 );
 
-const LATERAL_LABEL_CLASS = "text-2xl font-bold";
+const LATERAL_LABEL_CLASS = "text-[22px] lg:text-2xl font-bold";
 
 // Stable constant — avoids recreating the array on every render
 const LP_SIZE_ANNOTATIONS = [
@@ -76,59 +76,8 @@ const GetStartedChart = () => {
 
   return (
     <div className="bg-[#F4F6FA] text-navy w-full mx-auto max-w-8xl py-4 px-6 md:px-12">
-      {/* ── MOBILE LAYOUT ── */}
-      <div className="flex flex-col gap-6 md:hidden">
-        {/* LP section */}
-        <div>
-          <p className={`text-center mb-1 ${LATERAL_LABEL_CLASS}`}>
-            Linear programming problems
-          </p>
-          <p className="text-center text-sm font-semibold text-navy/70 mb-3">
-            Slowdown relative to the fastest solver
-          </p>
-          <ChartResultsSections
-            hideLegend
-            showBarTopLabels
-            sizeAnnotations={LP_SIZE_ANNOTATIONS}
-          />
-          <p className="text-center text-sm font-semibold text-navy/70 mt-6 mb-3">
-            Problems solved within time and memory limits (%)
-          </p>
-          <ChartResultsSectionsVarians
-            hideLegend
-            sizeAnnotations={LP_SIZE_ANNOTATIONS}
-          />
-        </div>
-
-        {/* MILP section */}
-        <div>
-          <p className={`text-center mb-1 ${LATERAL_LABEL_CLASS}`}>
-            Mixed-integer linear programming problems
-          </p>
-          <p className="text-center text-sm font-semibold text-navy/70 mb-3">
-            Slowdown relative to the fastest solver
-          </p>
-          <ChartResultsSections
-            problemClass="MILP"
-            hideLegend
-            rightmostGroupNote={MILP_NOTE}
-            rightmostGroupOpacity={0.4}
-            sizeAnnotations={LP_SIZE_ANNOTATIONS}
-          />
-          <p className="text-center text-sm font-semibold text-navy/70 mt-6 mb-3">
-            Problems solved within time and memory limits (%)
-          </p>
-          <ChartResultsSectionsVarians
-            problemClass="MILP"
-            hideLegend
-            sizeAnnotations={LP_SIZE_ANNOTATIONS}
-            rightmostGroupOpacity={0.4}
-          />
-        </div>
-      </div>
-
       {/* ── DESKTOP LAYOUT ── */}
-      <div className="hidden md:block">
+      <div className=" md:block">
         {/* Top row: slowdown panels */}
         <div className="text-center gap-0 mt-1">
           <div className="shrink-0 relative">
@@ -144,9 +93,6 @@ const GetStartedChart = () => {
               showBarTopLabels
               sizeAnnotations={LP_SIZE_ANNOTATIONS}
             />
-            <div className={`xl:hidden text-center ${LATERAL_LABEL_CLASS}`}>
-              Linear programming problems
-            </div>
             <ChartResultsSections
               problemClass="MILP"
               hideLegend

--- a/website/src/components/landing-page/sections/SgmRuntimeChart.tsx
+++ b/website/src/components/landing-page/sections/SgmRuntimeChart.tsx
@@ -231,6 +231,7 @@ const SgmRuntimeChart = ({
         tooltipFormat={tooltipFormat}
         axisLabelTitle={getAxisLabelTitle}
         xAxisTickFormat={getXAxisTickFormat}
+        xAxisBarTextClassName="text-[9px] sm:text-[10px] lg:text-xs fill-dark-grey"
         directionalIndicator={mode === "solved-pct" ? "higher" : "lower"}
         useLogScale={mode !== "solved-pct"}
         normalize={mode !== "solved-pct"}

--- a/website/src/components/shared/D3GroupedBarChart.tsx
+++ b/website/src/components/shared/D3GroupedBarChart.tsx
@@ -618,6 +618,7 @@ const D3GroupedBarChart = ({
 
   return (
     <div
+      key={windowWidth}
       className="relative bg-[#F4F6FA] rounded-2xl p-2"
       style={{ background: "#F4F6FA" }}
     >

--- a/website/src/components/shared/D3GroupedBarChart.tsx
+++ b/website/src/components/shared/D3GroupedBarChart.tsx
@@ -364,8 +364,7 @@ const D3GroupedBarChart = ({
             .attr("dominant-baseline", "central")
             .attr("transform", `translate(${xPos}, ${nameY}) rotate(-90)`)
             .attr("fill", solverColor)
-            .style("font-size", "16px")
-            .classed("font-bold", true)
+            .classed("font-bold text-[12px] sm:text-base", true)
             .text(getSolverLabel(d.key));
         }
       })
@@ -636,7 +635,8 @@ const D3GroupedBarChart = ({
         </div>
       )}
       {directionalIndicator && (
-        <div className="absolute -right-4 xl:-right-0 top-1/2 transform -translate-y-1/2">
+        // <div className="absolute -right-4 xl:-right-0 top-1/2 transform -translate-y-1/2">
+        <div className="absolute -right-4 xl:-right-0 top-1/2 transform -translate-y-1/2 w-[80px]">
           <DirectionalIndicator direction={directionalIndicator} size="sm" />
         </div>
       )}


### PR DESCRIPTION

<!-- Title: Please prefix your PR title with `Benchmarks:`, `Website:`, `Runner:` etc, and use a short description of your changes in active voice, e.g. `add TIMES instances` or `fix scrollbar on performance history page`. -->

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Fixes https://github.com/open-energy-transition/solver-benchmark/issues/538

**For changes to the website:**
- [x] I have tested my changes by running the website locally

<img width="560" height="8228" alt="image" src="https://github.com/user-attachments/assets/9170d645-4a05-42ee-9530-cbbbfa316d24" />
