### PR TITLE
Handle empty benchmark allocations in quickstart notebook

### DIFF
--- a/runner/utils.py
+++ b/runner/utils.py
@@ -252,9 +252,13 @@ def allocate_benchmarks(
     timeout_seconds: int | None = None,
     years: list[int] = [2020, 2022, 2023, 2024, 2025],
 ) -> list[dict]:
+    if benchmarks_df.empty:
+        return []
+
     allocation, _ = allocate_vms_greedy(
         benchmarks_df.index, benchmarks_df[weight_col], num_vms
     )
+
     vm_yamls = []
     for benchs in allocation:
         vm_benchmarks = {}


### PR DESCRIPTION
## Summary

This PR makes `allocate_benchmarks` gracefully handle empty benchmark selections:
- Return an empty list when the input benchmark DataFrame is empty.
- Avoid calling the allocation routine when there are no benchmarks to allocate.

Some benchmark campaigns intentionally filter subsets of benchmarks (e.g. only S/M instances). When a subset is empty, `allocate_benchmarks` was still calling the allocation routine with zero benchmarks and zero VMs, causing an exception when using the quickstart notebook:

```text
ValueError: max() iterable argument is empty
```

With this change, empty benchmark selections are treated as a valid case and simply produce no VM configurations, allowing the remainder of the campaign generation to proceed normally.