### PR TITLE
MERGE ONLY AFTER runv3! Display quality metrics on the Website

### DIFF
--- a/runner/run_benchmarks.py
+++ b/runner/run_benchmarks.py
@@ -258,11 +258,9 @@ def benchmark_solver(input_file, solver_name, timeout, solver_version):
             solver_name,
             input_file,
             solver_version,
+            str(timeout),
         ]
     )
-
-    env = os.environ.copy()
-    env["SOLVER_TIMEOUT_SECONDS"] = str(timeout)
 
     # Run the command and capture the output
     result = subprocess.run(
@@ -271,7 +269,6 @@ def benchmark_solver(input_file, solver_name, timeout, solver_version):
         text=True,
         check=False,
         encoding="utf-8",
-        env=env,
     )
 
     # Append the stderr to the log file

--- a/runner/run_benchmarks.py
+++ b/runner/run_benchmarks.py
@@ -258,9 +258,11 @@ def benchmark_solver(input_file, solver_name, timeout, solver_version):
             solver_name,
             input_file,
             solver_version,
-            str(timeout),
         ]
     )
+
+    env = os.environ.copy()
+    env["SOLVER_TIMEOUT_SECONDS"] = str(timeout)
 
     # Run the command and capture the output
     result = subprocess.run(
@@ -269,6 +271,7 @@ def benchmark_solver(input_file, solver_name, timeout, solver_version):
         text=True,
         check=False,
         encoding="utf-8",
+        env=env,
     )
 
     # Append the stderr to the log file

--- a/runner/run_benchmarks.py
+++ b/runner/run_benchmarks.py
@@ -127,6 +127,7 @@ def csv_record(check=False, **kwargs):
             ("Runtime (s)", kwargs.get("runtime")),
             ("Memory Usage (MB)", kwargs.get("memory")),
             ("Objective Value", kwargs.get("objective")),
+            ("MIP Gap", kwargs.get("mip_gap")),
             ("Max Integrality Violation", kwargs.get("max_integrality_violation")),
             ("Duality Gap", kwargs.get("duality_gap")),
             ("Reported Runtime (s)", kwargs.get("reported_runtime")),
@@ -336,6 +337,9 @@ def benchmark_solver(input_file, solver_name, timeout, solver_version):
     if metrics["status"] not in {"ok", "TO", "ER", "OOM"}:
         print(f"WARNING: unknown solver status: {metrics['status']}")
 
+    metrics.setdefault("mip_gap", None)
+    metrics.setdefault("duality_gap", None)
+    metrics.setdefault("max_integrality_violation", None)
     metrics["memory"] = memory
     metrics["timeout"] = timeout
 

--- a/runner/run_benchmarks.py
+++ b/runner/run_benchmarks.py
@@ -252,12 +252,13 @@ def benchmark_solver(input_file, solver_name, timeout, solver_version):
             "--format",
             "MaxResidentSetSizeKB=%M",
             "timeout",
-            f"{timeout}s",
+            f"{timeout + 60}s",
             "python",
             f"{Path(__file__).parent / 'run_solver.py'}",
             solver_name,
             input_file,
             solver_version,
+            str(timeout),
         ]
     )
 

--- a/runner/run_solver.py
+++ b/runner/run_solver.py
@@ -84,12 +84,11 @@ def get_solver(solver_name, timeout=None):
 
     timeout_options = {
         "highs": {"time_limit": timeout},
-        "glpk": {"tmlim": timeout},
         "gurobi": {"TimeLimit": timeout},
         "scip": {"limits/time": timeout},
         "cbc": {"seconds": timeout},
         "cplex": {"timelimit": timeout},
-        "xpress": {"maxtime": timeout},
+        "xpress": {"timelimit": timeout},
     }
 
     options = seed_options.get(solver_name, {}).copy()
@@ -289,6 +288,23 @@ def get_reported_runtime(solver_name, solver_model) -> float | None:
     except Exception:
         print(f"ERROR obtaining reported runtime: {format_exc()}", file=sys.stderr)
     return None
+
+
+def log_indicates_timeout(log_fn: Path) -> bool:
+    if not log_fn.exists():
+        return False
+
+    try:
+        log_text = log_fn.read_text(errors="ignore")
+    except Exception:
+        return False
+
+    timeout_markers = [
+        "Time limit reached",
+        "time limit",
+        "timelimit",
+    ]
+    return any(marker.lower() in log_text.lower() for marker in timeout_markers)
 
 
 def run_highs_hipo_solver(input_file, solver_version, highs_variant: HighsVariant):
@@ -508,18 +524,40 @@ def main(solver_name, input_file, solver_version):
             "duality_gap": quality_metrics["duality_gap"],
             "max_integrality_violation": quality_metrics["max_integrality_violation"],
         }
+        condition = str(results["condition"]).lower()
+
+        if "time" in condition and "limit" in condition:
+            results["status"] = "TO"
+            results["condition"] = "Timeout"
     except Exception:
-        print(f"ERROR running solver: {format_exc()}", file=sys.stderr)
-        results = {
-            "runtime": None,
-            "reported_runtime": None,
-            "status": "ER",
-            "condition": None,
-            "objective": None,
-            "mip_gap": None,
-            "duality_gap": None,
-            "max_integrality_violation": None,
-        }
+        if log_indicates_timeout(log_fn):
+            runtime = perf_counter() - start_time
+            print(
+                "WARNING: solver reached time limit before a solution could be parsed",
+                file=sys.stderr,
+            )
+            results = {
+                "runtime": runtime,
+                "reported_runtime": None,
+                "status": "TO",
+                "condition": "Timeout",
+                "objective": None,
+                "mip_gap": None,
+                "duality_gap": None,
+                "max_integrality_violation": None,
+            }
+        else:
+            print(f"ERROR running solver: {format_exc()}", file=sys.stderr)
+            results = {
+                "runtime": None,
+                "reported_runtime": None,
+                "status": "ER",
+                "condition": None,
+                "objective": None,
+                "mip_gap": None,
+                "duality_gap": None,
+                "max_integrality_violation": None,
+            }
     print(json.dumps(results))
 
 

--- a/runner/run_solver.py
+++ b/runner/run_solver.py
@@ -56,20 +56,20 @@ except ModuleNotFoundError:
     highspy = None
 
 
-def get_solver(solver_name):
+def get_solver(solver_name, timeout=None):
     solver_name = solver_name.lower()
     solver_enum = SolverName(solver_name)
 
     solver_class = getattr(solvers, solver_enum.name)
 
-    mip_gap = 1e-4  # Tolerance for the relative duality gap for MILPs
+    mip_gap = 1e-4  # Tolerance for the relative MIP gap for MILPs.
     seed_options = {
         "highs": {"random_seed": 0, "mip_rel_gap": mip_gap},
         "glpk": {"seed": 0, "mipgap": mip_gap},
         "gurobi": {"seed": 0, "MIPGap": mip_gap},
         "scip": {"randomization/randomseedshift": 0, "limits/gap": mip_gap},
         "cbc": {
-            "randomCbcSeed": 1,  # 0 indicates time of day
+            "randomCbcSeed": 1,  # 0 indicates time of day.
             "ratioGap": mip_gap,
         },
         "cplex": {
@@ -82,7 +82,22 @@ def get_solver(solver_name):
         "xpress": {"miprelgapnotify": mip_gap, "randomseed": 0},
     }
 
-    return solver_class(**seed_options.get(solver_name, {}))
+    timeout_options = {
+        "highs": {"time_limit": timeout},
+        "glpk": {"tmlim": timeout},
+        "gurobi": {"TimeLimit": timeout},
+        "scip": {"limits/time": timeout},
+        "cbc": {"seconds": timeout},
+        "cplex": {"timelimit": timeout},
+        "xpress": {"maxtime": timeout},
+    }
+
+    options = seed_options.get(solver_name, {}).copy()
+
+    if timeout is not None:
+        options.update(timeout_options.get(solver_name, {}))
+
+    return solver_class(**options)
 
 
 def is_mip_problem(solver_model, solver_name):
@@ -430,7 +445,7 @@ def run_highs_hipo_solver(input_file, solver_version, highs_variant: HighsVarian
         #         pass
 
 
-def main(solver_name, input_file, solver_version):
+def main(solver_name, input_file, solver_version, timeout=None):
     problem_file = Path(input_file)
 
     # Handle highs-hipo solver variants separately
@@ -445,7 +460,7 @@ def main(solver_name, input_file, solver_version):
         if "is not a valid HighsVariant" not in str(e):
             raise e
 
-    solver = get_solver(solver_name)
+    solver = get_solver(solver_name, timeout)
 
     solution_dir = Path(__file__).parent / "solutions"
     solution_dir.mkdir(parents=True, exist_ok=True)
@@ -497,11 +512,16 @@ def main(solver_name, input_file, solver_version):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 4:
-        print("Usage: python run_solver.py <solver_name> <input_file> <solver_version>")
+    if len(sys.argv) not in {4, 5}:
+        print(
+            "Usage: python run_solver.py <solver_name> <input_file> "
+            "<solver_version> [timeout_seconds]"
+        )
         sys.exit(1)
 
     solver_name = sys.argv[1]
     input_file = sys.argv[2]
     solver_version = sys.argv[3]
-    main(solver_name, input_file, solver_version)
+    timeout = float(sys.argv[4]) if len(sys.argv) == 5 else None
+
+    main(solver_name, input_file, solver_version, timeout)

--- a/runner/run_solver.py
+++ b/runner/run_solver.py
@@ -470,7 +470,7 @@ def run_highs_hipo_solver(input_file, solver_version, highs_variant: HighsVarian
         #         pass
 
 
-def main(solver_name, input_file, solver_version):
+def main(solver_name, input_file, solver_version, timeout):
     problem_file = Path(input_file)
 
     # Handle highs-hipo solver variants separately
@@ -484,9 +484,6 @@ def main(solver_name, input_file, solver_version):
         # we want to continue only if the error is about invalid HighsVariant
         if "is not a valid HighsVariant" not in str(e):
             raise e
-
-    timeout_seconds = os.environ.get("SOLVER_TIMEOUT_SECONDS")
-    timeout = float(timeout_seconds) if timeout_seconds else None
 
     solver = get_solver(solver_name, timeout)
 

--- a/runner/run_solver.py
+++ b/runner/run_solver.py
@@ -445,7 +445,7 @@ def run_highs_hipo_solver(input_file, solver_version, highs_variant: HighsVarian
         #         pass
 
 
-def main(solver_name, input_file, solver_version, timeout=None):
+def main(solver_name, input_file, solver_version):
     problem_file = Path(input_file)
 
     # Handle highs-hipo solver variants separately
@@ -459,6 +459,9 @@ def main(solver_name, input_file, solver_version, timeout=None):
         # we want to continue only if the error is about invalid HighsVariant
         if "is not a valid HighsVariant" not in str(e):
             raise e
+
+    timeout_seconds = os.environ.get("SOLVER_TIMEOUT_SECONDS")
+    timeout = float(timeout_seconds) if timeout_seconds else None
 
     solver = get_solver(solver_name, timeout)
 
@@ -512,16 +515,12 @@ def main(solver_name, input_file, solver_version, timeout=None):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) not in {4, 5}:
-        print(
-            "Usage: python run_solver.py <solver_name> <input_file> "
-            "<solver_version> [timeout_seconds]"
-        )
+    if len(sys.argv) != 4:
+        print("Usage: python run_solver.py <solver_name> <input_file> <solver_version>")
         sys.exit(1)
 
     solver_name = sys.argv[1]
     input_file = sys.argv[2]
     solver_version = sys.argv[3]
-    timeout = float(sys.argv[4]) if len(sys.argv) == 5 else None
 
-    main(solver_name, input_file, solver_version, timeout)
+    main(solver_name, input_file, solver_version)

--- a/runner/run_solver.py
+++ b/runner/run_solver.py
@@ -129,55 +129,116 @@ def calculate_integrality_violation(
     return max((p - p.round()).abs())
 
 
-def get_duality_gap(solver_model, solver_name: str):
-    """Retrieve the duality gap for the given solver model, if available."""
-    if solver_name == "scip":
-        return solver_model.getGap()
-    elif solver_name == "gurobi":
-        return solver_model.MIPGap
-    elif solver_name == "highs":
-        return getattr(solver_model.getInfo(), "mip_gap", None)
-    elif solver_name == "cbc":
-        return getattr(solver_model, "mip_gap", None)
-    elif solver_name == "glpk":
-        # GLPK does not have a way to retrieve the duality gap from python
-        return None
-    elif solver_name == "cplex":
-        return solver_model.solution.MIP.get_mip_relative_gap()
-    elif solver_name == "xpress":
-        return solver_model.controls.miprelgapnotify
-    elif solver_name == "knitro":
-        # Knitro duality gap retrieval not implemented yet
-        return None
-    else:
-        raise NotImplementedError(f"The solver '{solver_name}' is not supported.")
-
-
-def get_milp_metrics(input_file, solver_result):
-    """Uses HiGHS to read the problem file and compute max integrality violation and
-    duality gap.
-    """
+def get_mip_gap(solver_model, solver_name: str):
+    """Retrieve the final relative MIP gap, if available."""
     try:
-        if highspy is not None:
-            h = highspy.Highs()
-            h.readModel(input_file)
-            integer_vars = {
-                h.variableName(i)
-                for i in range(h.numVariables)
-                if h.getColIntegrality(i)[1] == highspy.HighsVarType.kInteger
-            }
-            if integer_vars:
-                duality_gap = get_duality_gap(solver_result.solver_model, solver_name)
-                max_integrality_violation = calculate_integrality_violation(
-                    integer_vars, solver_result.solution.primal
-                )
-                return duality_gap, max_integrality_violation
+        match solver_name:
+            case "scip":
+                return solver_model.getGap()
+            case "gurobi":
+                return solver_model.MIPGap
+            case "highs":
+                return getattr(solver_model.getInfo(), "mip_gap", None)
+            case "cbc":
+                return getattr(solver_model, "mip_gap", None)
+            case "glpk":
+                return None
+            case "cplex":
+                return solver_model.solution.MIP.get_mip_relative_gap()
+            case "xpress":
+                return solver_model.getAttrib("mipgap")
+            case "knitro":
+                return None
+            case _:
+                print(f"WARNING: cannot obtain MIP gap for {solver_name}")
+                return None
+    except Exception:
+        print(f"ERROR obtaining MIP gap: {format_exc()}", file=sys.stderr)
+    return None
+
+
+def get_lp_duality_gap(solver_model, solver_name: str):
+    """Retrieve the final LP duality gap, if available."""
+    try:
+        match solver_name:
+            case "highs":
+                info = solver_model.getInfo()
+                return getattr(info, "primal_dual_objective_error", None)
+            case "gurobi":
+                # Gurobi exposes barrier convergence tolerances and quality attributes,
+                # but not a single solver-independent final LP duality gap through the
+                # current linopy solver object. Do not report BarConvTol here: it is a
+                # stopping tolerance, not the realized duality gap.
+                return None
+            case "scip" | "cbc" | "glpk" | "cplex" | "xpress" | "knitro":
+                return None
+            case _:
+                print(f"WARNING: cannot obtain LP duality gap for {solver_name}")
+                return None
+    except Exception:
+        print(f"ERROR obtaining LP duality gap: {format_exc()}", file=sys.stderr)
+    return None
+
+
+def get_integer_variables(input_file):
+    """Return integer variable names from the problem file, if available."""
+    if highspy is None:
+        return None
+
+    h = highspy.Highs()
+    h.readModel(input_file)
+
+    return {
+        h.variableName(i)
+        for i in range(h.numVariables)
+        if h.getColIntegrality(i)[1] == highspy.HighsVarType.kInteger
+    }
+
+
+def get_max_integrality_violation(input_file, primal_values):
+    """Calculate max integrality violation from the solution values."""
+    try:
+        integer_vars = get_integer_variables(input_file)
+
+        if integer_vars is None:
+            return None
+
+        if not integer_vars:
+            return 0.0
+
+        return calculate_integrality_violation(integer_vars, primal_values)
     except Exception:
         print(
-            f"ERROR obtaining milp metrics for {input_file}: {format_exc()}",
+            f"ERROR obtaining max integrality violation for {input_file}: {format_exc()}",
             file=sys.stderr,
         )
-    return None, None
+    return None
+
+
+def get_quality_metrics(input_file, solver_result, solver_name: str):
+    """Collect solver quality metrics with clear LP/MILP semantics."""
+    try:
+        mip_problem = is_mip_problem(solver_result.solver_model, solver_name)
+    except Exception:
+        print(f"ERROR detecting problem type: {format_exc()}", file=sys.stderr)
+        mip_problem = None
+
+    if mip_problem:
+        return {
+            "mip_gap": get_mip_gap(solver_result.solver_model, solver_name),
+            "duality_gap": None,
+            "max_integrality_violation": get_max_integrality_violation(
+                input_file, solver_result.solution.primal
+            ),
+        }
+
+    return {
+        "mip_gap": None,
+        "duality_gap": get_lp_duality_gap(solver_result.solver_model, solver_name),
+        "max_integrality_violation": get_max_integrality_violation(
+            input_file, solver_result.solution.primal
+        ),
+    }
 
 
 def get_reported_runtime(solver_name, solver_model) -> float | None:
@@ -277,6 +338,7 @@ def run_highs_hipo_solver(input_file, solver_version, highs_variant: HighsVarian
                     "status": "ER",
                     "condition": "Error",
                     "objective": None,
+                    "mip_gap": None,
                     "duality_gap": None,
                     "max_integrality_violation": None,
                 }
@@ -339,6 +401,7 @@ def run_highs_hipo_solver(input_file, solver_version, highs_variant: HighsVarian
                     "objective": objective,
                     "duality_gap": None,  # Not available from command line output
                     "max_integrality_violation": None,  # Not available from command line output
+                    "mip_gap": None,
                 }
         except Exception as e:
             runtime = time.perf_counter() - start_time
@@ -353,6 +416,7 @@ def run_highs_hipo_solver(input_file, solver_version, highs_variant: HighsVarian
                 "status": "error",
                 "condition": "Error",
                 "objective": None,
+                "mip_gap": None,
                 "duality_gap": None,
                 "max_integrality_violation": None,
             }
@@ -403,9 +467,7 @@ def main(solver_name, input_file, solver_version):
         )
         runtime = perf_counter() - start_time
 
-        duality_gap, max_integrality_violation = get_milp_metrics(
-            input_file, solver_result
-        )
+        quality_metrics = get_quality_metrics(input_file, solver_result, solver_name)
 
         results = {
             "runtime": runtime,
@@ -415,8 +477,9 @@ def main(solver_name, input_file, solver_version):
             "status": solver_result.status.status.value,
             "condition": solver_result.status.termination_condition.value,
             "objective": solver_result.solution.objective,
-            "duality_gap": duality_gap,
-            "max_integrality_violation": max_integrality_violation,
+            "mip_gap": quality_metrics["mip_gap"],
+            "duality_gap": quality_metrics["duality_gap"],
+            "max_integrality_violation": quality_metrics["max_integrality_violation"],
         }
     except Exception:
         print(f"ERROR running solver: {format_exc()}", file=sys.stderr)
@@ -426,6 +489,7 @@ def main(solver_name, input_file, solver_version):
             "status": "ER",
             "condition": None,
             "objective": None,
+            "mip_gap": None,
             "duality_gap": None,
             "max_integrality_violation": None,
         }

--- a/runner/run_solver.py
+++ b/runner/run_solver.py
@@ -203,11 +203,20 @@ def get_integer_variables(input_file):
     h = highspy.Highs()
     h.readModel(input_file)
 
-    return {
-        h.variableName(i)
-        for i in range(h.numVariables)
-        if h.getColIntegrality(i)[1] == highspy.HighsVarType.kInteger
-    }
+    lp = h.getLp()
+    integer_vars = set()
+
+    integrality = getattr(lp, "integrality_", None)
+    col_names = getattr(lp, "col_names_", [])
+
+    if integrality is None:
+        return integer_vars
+
+    for name, var_type in zip(col_names, integrality, strict=False):
+        if var_type == highspy.HighsVarType.kInteger:
+            integer_vars.add(name)
+
+    return integer_vars
 
 
 def get_max_integrality_violation(input_file, primal_values):

--- a/website/src/components/admin/raw-result/TableResult.tsx
+++ b/website/src/components/admin/raw-result/TableResult.tsx
@@ -148,6 +148,16 @@ const TableResult = () => {
         cell: (info: CellContext<BenchmarkResult, unknown>) =>
           formatScientific(info.getValue() as number, ""),
       },
+      {
+        header: "MIP Gap",
+        accessorKey: "mipGap",
+        meta: {
+          filterVariant: "range",
+        },
+        filterFn: filterNumber,
+        cell: (info: CellContext<BenchmarkResult, unknown>) =>
+          formatScientific(info.getValue() as number, ""),
+      },
     ],
     [],
   );

--- a/website/src/types/benchmark.ts
+++ b/website/src/types/benchmark.ts
@@ -4,6 +4,7 @@ type SolverStatusType = "TO" | "ok" | "warning" | "ER" | "OOM";
 type BenchmarkResult = {
   benchmark: string;
   dualityGap: number | null;
+  mipGap: number | null;
   maxIntegralityViolation: number | null;
   memoryUsage: number;
   objectiveValue: number | null;
@@ -57,6 +58,7 @@ interface OriginBenchmarkResult {
   "Objective Value": number | null;
   "Max Integrality Violation": number | null;
   "Duality Gap": number | null;
+  "MIP Gap": number | null;
 }
 
 type IFilterBenchmarkDetails = {

--- a/website/src/utils/results.ts
+++ b/website/src/utils/results.ts
@@ -66,6 +66,7 @@ const getBenchmarkResults = async (
     return {
       benchmark: data["Benchmark"],
       dualityGap: parseNumberOrNull(data["Duality Gap"]),
+      mipGap: parseNumberOrNull(data["MIP Gap"]),
       maxIntegralityViolation: parseNumberOrNull(
         data["Max Integrality Violation"],
       ),


### PR DESCRIPTION
## Summary

This PR updates the website to expose the newly collected solver quality metrics in the benchmark results table.

### Changes

- Add **MIP Gap** to the Full Results table.
- Extend the benchmark result types to include the new metric.
- Parse the `MIP Gap` column from the benchmark results CSV.
- Keep the frontend data model aligned with the benchmark runner output.

## Notes

**This PR depends on the benchmark runner changes that introduce the new quality metrics into the generated CSV files. It should therefore be merged after the corresponding backend PR.**