### PR TITLE
Runner: update Linopy to 0.9.0

### DIFF
--- a/runner/envs/benchmark-2025-fixed.yaml
+++ b/runner/envs/benchmark-2025-fixed.yaml
@@ -2,140 +2,101 @@ name: benchmark-2025
 channels:
   - conda-forge
   - gurobi
+  - https://conda.anaconda.org/gurobi
   - nodefaults
 dependencies:
   - _openmp_mutex=4.5=7_kmp_llvm
-  - _python_abi3_support=1.0=hd8ed1ab_2
-  - aiohappyeyeballs=2.6.1=pyhd8ed1ab_0
-  - aiohttp=3.13.2=py312h27b7581_0
-  - aiosignal=1.4.0=pyhd8ed1ab_0
+  - _python_abi3_support=1.0=hd8ed1ab_3
   - ampl-asl=1.0.0=h5888daf_2
-  - attrs=25.4.0=pyhcf101f3_1
-  - backports.zstd=1.2.0=py312h90b7ffd_0
+  - backports.zstd=1.6.0=py312h90b7ffd_0
   - bottleneck=1.6.0=np2py312hfb8c2c5_3
   - brotli-python=1.2.0=py312hdb49522_1
-  - bzip2=1.0.8=hda65f42_8
-  - c-ares=1.34.5=hb9d3cd8_0
-  - ca-certificates=2025.11.12=hbd8a1cb_0
-  - cachetools=6.2.2=pyhd8ed1ab_0
-  - certifi=2025.11.12=pyhd8ed1ab_0
-  - cffi=2.0.0=py312h460c074_1
-  - charset-normalizer=3.4.4=pyhd8ed1ab_0
-  - click=8.3.1=pyh8f84b5b_1
-  - cloudpickle=3.1.2=pyhd8ed1ab_0
-  - colorama=0.4.6=pyhd8ed1ab_1
-  - cpython=3.12.12=py312hd8ed1ab_1
-  - cryptography=46.0.3=py312ha4b625e_1
-  - dask-core=2025.11.0=pyhcf101f3_0
+  - bzip2=1.0.8=hda65f42_9
+  - ca-certificates=2026.7.22=hbd8a1cb_0
+  - certifi=2026.7.22=pyhd8ed1ab_0
+  - charset-normalizer=3.4.9=pyhd8ed1ab_0
+  - click=8.4.2=pyhc90fa1f_0
+  - cloudpickle=3.1.2=pyhcf101f3_1
+  - cpython=3.12.13=py312hd8ed1ab_0
+  - dask-core=2026.7.1=pyhc364b38_0
   - deprecation=2.1.0=pyh9f0ad1d_0
-  - frozenlist=1.7.0=py312h447239a_0
-  - fsspec=2025.12.0=pyhd8ed1ab_0
+  - fsspec=2026.7.0=pyhd8ed1ab_0
   - gmp=6.3.0=hac33072_2
-  - google-api-core=2.28.1=pyhd8ed1ab_0
-  - google-auth=2.43.0=pyhd8ed1ab_0
-  - google-cloud-core=2.5.0=pyhd8ed1ab_0
-  - google-cloud-storage=3.6.0=pyhcf101f3_0
-  - google-crc32c=1.7.1=py312h03f33d3_1
-  - google-resumable-media=2.8.0=pyhd8ed1ab_0
-  - googleapis-common-protos=1.72.0=pyhd8ed1ab_0
-  - grpcio=1.74.1=py312h6f3464c_1
-  - grpcio-status=1.74.0=pyhd8ed1ab_0
   - gurobi=13.0.0=py312_0
-  - h2=4.3.0=pyhcf101f3_0
+  - h2=4.4.0=pyhcf101f3_0
   - highspy=1.12.0=np2py312h0f77346_0
-  - hpack=4.1.0=pyhd8ed1ab_0
+  - hpack=4.2.0=pyhd8ed1ab_0
   - hyperframe=6.1.0=pyhd8ed1ab_0
-  - idna=3.11=pyhd8ed1ab_0
-  - importlib-metadata=8.7.0=pyhe01879c_1
-  - ipopt=3.14.19=h6c08d29_1
-  - ld_impl_linux-64=2.45=default_hbd61a6d_104
-  - legacy-cgi=2.6.4=pyhcf101f3_0
-  - libabseil=20250512.1=cxx17_hba17884_0
-  - libblas=3.11.0=4_h4a7cf45_openblas
-  - libcblas=3.11.0=4_h0358290_openblas
-  - libcrc32c=1.1.2=h9c3ff4c_0
-  - libexpat=2.7.3=hecca717_0
-  - libffi=3.5.2=h9ec8514_0
-  - libgcc=15.2.0=he0feb66_15
-  - libgcc-ng=15.2.0=h69a702a_15
-  - libgfortran=15.2.0=h69a702a_15
-  - libgfortran5=15.2.0=h68bc16d_15
-  - libgrpc=1.74.1=h3288cfb_1
-  - libhwloc=2.12.1=default_hafda6a7_1003
+  - icu=78.3=h54a6638_2
+  - idna=3.18=pyhcf101f3_0
+  - importlib-metadata=9.0.0=pyhcf101f3_0
+  - ipopt=3.14.19=he45328a_2
+  - ld_impl_linux-64=2.46.1=default_hbd61a6d_102
+  - libblas=3.11.0=8_h4a7cf45_openblas
+  - libcblas=3.11.0=8_h0358290_openblas
+  - libexpat=2.8.1=hecca717_1
+  - libffi=3.5.2=h3435931_0
+  - libgcc=16.1.0=ha9f2e26_1
+  - libgcc-ng=16.1.0=h69a702a_1
+  - libgfortran=16.1.0=h69a702a_1
+  - libgfortran5=16.1.0=h79bb938_1
+  - libhwloc=2.13.0=default_he001693_1000
   - libiconv=1.18=h3b78370_2
-  - liblapack=3.11.0=4_h47877c9_openblas
-  - liblzma=5.8.1=hb9d3cd8_2
+  - liblapack=3.11.0=8_h47877c9_openblas
+  - liblzma=5.8.3=hb03c661_0
   - libnsl=2.0.1=hb9d3cd8_1
-  - libopenblas=0.3.30=openmp_hd680484_4
-  - libprotobuf=6.31.1=h49aed37_2
-  - libre2-11=2025.11.05=h7b12aa8_0
-  - libscotch=7.0.10=int32_h8512f2c_2
-  - libspral=2025.05.20=hfabd9d1_1
-  - libsqlite=3.51.1=h0c1763c_0
-  - libstdcxx=15.2.0=h934c35e_15
-  - libstdcxx-ng=15.2.0=hdf11a46_15
-  - libuuid=2.41.2=h5347b49_1
+  - libopenblas=0.3.33=openmp_hd680484_0
+  - libscotch=7.0.11=int64_h807e49d_3
+  - libspral=2025.09.18=h74cae3c_2
+  - libsqlite=3.53.4=hf4e2dac_0
+  - libstdcxx=16.1.0=h934c35e_1
+  - libstdcxx-ng=16.1.0=hdf11a46_1
+  - libuuid=2.42.2=h5347b49_0
   - libxcrypt=4.4.36=hd590300_1
-  - libxml2=2.15.1=h031cc0b_0
-  - libxml2-16=2.15.1=hf2a90c1_0
-  - libzlib=1.3.1=hb9d3cd8_2
-  - linopy=0.5.8=pyhd8ed1ab_0
-  - llvm-openmp=21.1.7=h4922eb0_0
+  - libxml2=2.15.3=h49c6c72_0
+  - libxml2-16=2.15.3=hca6bf5a_0
+  - libzlib=1.3.2=h25fd6f3_3
+  - linopy=0.9.0=pyhc364b38_0
+  - llvm-openmp=22.1.8=h4922eb0_0
   - locket=1.0.0=pyhd8ed1ab_0
   - metis=5.1.0=hd0bcaf9_1007
-  - mpfr=4.2.1=h90cbb55_3
-  - multidict=6.6.3=py312h178313f_0
-  - mumps-include=5.8.1=h1795ed4_4
-  - mumps-seq=5.8.1=h4374b6a_4
-  - ncurses=6.5=h2d0b736_3
+  - mpfr=4.2.2=he0a73b1_0
+  - mumps-include=5.8.2=h5a610fb_2
+  - mumps-seq=5.8.2=hc1b3267_2
+  - ncurses=6.6=hdb14827_0
   - nomkl=1.0=h5ca1d4c_0
-  - numexpr=2.14.1=py312h88efc94_101
-  - numpy=1.26.4=py312heda63a1_0
-  - openssl=3.6.0=h26f9b46_0
-  - packaging=25.0=pyh29332c3_1
-  - pandas=2.3.3=py312hf79963d_1
+  - numexpr=2.14.2=py312h88efc94_100
+  - numpy=2.5.1=py312h33ff503_0
+  - openssl=3.6.3=h35e630c_0
+  - packaging=26.2=pyhc364b38_0
+  - pandas=3.0.5=py312h8ecdadd_1
   - partd=1.4.2=pyhd8ed1ab_0
-  - pip=25.3=pyh8b19718_0
-  - polars=1.35.2=pyh6a1acc5_0
-  - polars-runtime-32=1.35.2=py310hffdcd12_0
-  - propcache=0.3.1=py312h178313f_0
-  - proto-plus=1.26.1=pyhd8ed1ab_0
-  - protobuf=6.31.1=py312hb8af0ac_2
-  - psutil=7.1.3=py312h5253ce2_0
-  - pyasn1=0.6.1=pyhd8ed1ab_2
-  - pyasn1-modules=0.4.2=pyhd8ed1ab_0
-  - pycparser=2.22=pyh29332c3_1
-  - pyopenssl=25.3.0=pyhd8ed1ab_0
+  - pip=26.2=pyh8b19718_0
+  - polars=1.43.2=pyh8da0edf_0
+  - polars-runtime-32=1.43.2=py310h9585f58_0
+  - psutil=7.2.2=py312h5253ce2_0
   - pysocks=1.7.1=pyha55dd90_7
-  - python=3.12.12=hd63d673_1_cpython
+  - python=3.12.13=hd63d673_0_cpython
   - python-dateutil=2.9.0.post0=pyhe01879c_2
-  - python-gil=3.12.12=hd8ed1ab_1
-  - python-tzdata=2025.2=pyhd8ed1ab_0
+  - python-gil=3.12.13=hd8ed1ab_0
   - python_abi=3.12=8_cp312
-  - pytz=2025.2=pyhd8ed1ab_0
-  - pyu2f=0.1.5=pyhd8ed1ab_1
-  - pyyaml=6.0.3=py312h8a5da7c_0
-  - re2=2025.11.05=h5301d42_0
-  - readline=8.2=h8c095d6_2
-  - requests=2.32.5=pyhd8ed1ab_0
-  - rsa=4.9.1=pyhd8ed1ab_0
-  - scip=10.0.0=hd8b5c82_0
-  - scipy=1.16.3=py312h7a1785b_1
-  - setuptools=80.9.0=pyhff2d567_0
+  - pyyaml=6.0.3=py312h8a5da7c_1
+  - readline=8.3=h853b02a_0
+  - requests=2.34.2=pyhcf101f3_0
+  - scip=10.0.0=hd8b5c82_1
+  - scipy=1.18.0=py312h54fa4ab_0
+  - setuptools=83.0.0=pyh332efcf_0
   - six=1.17.0=pyhe01879c_1
-  - tbb=2022.3.0=h8d10470_1
-  - tk=8.6.13=noxft_ha0e22de_103
+  - tbb=2023.0.0=hab88423_2
+  - tk=8.6.13=noxft_hd70dff1_3
   - toolz=1.1.0=pyhd8ed1ab_1
-  - tqdm=4.67.1=pyhd8ed1ab_1
-  - typing-extensions=4.15.0=h396c80c_0
-  - typing_extensions=4.15.0=pyhcf101f3_0
-  - tzdata=2025b=h78e105d_0
-  - urllib3=2.6.0=pyhd8ed1ab_0
-  - wheel=0.45.1=pyhd8ed1ab_1
-  - xarray=2025.12.0=pyhcf101f3_0
+  - tqdm=4.70.0=pyh8f84b5b_0
+  - tzdata=2026c=h151e31d_0
+  - urllib3=2.7.0=pyhd8ed1ab_0
+  - wheel=0.47.0=pyhd8ed1ab_0
+  - xarray=2026.7.0=pyhc364b38_0
   - yaml=0.2.5=h280c20c_3
-  - yarl=1.22.0=py312h8a5da7c_0
-  - zipp=3.23.0=pyhcf101f3_1
+  - zipp=4.1.0=pyhcf101f3_0
   - zstd=1.5.7=hb78ec9c_6
   - pip:
       - pyscipopt==5.7.1

--- a/runner/envs/benchmark-2025.yaml
+++ b/runner/envs/benchmark-2025.yaml
@@ -4,12 +4,12 @@ channels:
 - https://conda.anaconda.org/gurobi
 - nodefaults
 dependencies:
-- python>=3.12
+- python>=3.12,<3.13
 - pip
 - psutil>=5.9
 
 - requests>=2.32
-- linopy>=0.5.5
+- linopy==0.9.0
 
 # No CBC release in 2025
 # - coin-or-cbc==2.10.12

--- a/runner/envs/benchmark-tests-fixed.yaml
+++ b/runner/envs/benchmark-tests-fixed.yaml
@@ -4,106 +4,103 @@ channels:
   - https://conda.anaconda.org/gurobi
   - nodefaults
 dependencies:
-  - _libgcc_mutex=0.1=conda_forge
-  - _openmp_mutex=4.5=2_kmp_llvm
+  - _openmp_mutex=4.5=20_gnu
   - ampl-asl=1.0.0=h5888daf_2
-  - brotli-python=1.1.0=py312h2ec8cdc_2
-  - bzip2=1.0.8=h4bc722e_7
-  - ca-certificates=2025.1.31=hbcca054_0
-  - certifi=2025.1.31=pyhd8ed1ab_0
-  - cffi=1.17.1=py312h06ac9bb_0
-  - charset-normalizer=3.4.1=pyhd8ed1ab_0
-  - coin-or-cbc=2.10.12=h8b142ea_1
-  - coin-or-cgl=0.60.9=h1d3f3f2_0
-  - coin-or-clp=1.17.10=h07f2a63_0
-  - coin-or-osi=0.108.11=h6514dde_1
-  - coin-or-utils=2.11.12=h99da652_1
+  - backports.zstd=1.6.0=py312h90b7ffd_0
+  - brotli-python=1.2.0=py312hdb49522_1
+  - bzip2=1.0.8=hda65f42_9
+  - ca-certificates=2026.7.22=hbd8a1cb_0
+  - certifi=2026.7.22=pyhd8ed1ab_0
+  - charset-normalizer=3.4.9=pyhd8ed1ab_0
+  - coin-or-cbc=2.10.12=h4d16d09_5
+  - coin-or-cgl=0.60.10=hc46dffc_1
+  - coin-or-clp=1.17.11=hc03379b_1
+  - coin-or-osi=0.108.12=hf4fecb4_1
+  - coin-or-utils=2.11.13=hc93afbd_1
   - cppad=20250000.2=h5888daf_0
   - glpk=5.0=h445213a_0
   - gmp=6.3.0=hac33072_2
-  - h2=4.2.0=pyhd8ed1ab_0
-  - hpack=4.1.0=pyhd8ed1ab_0
+  - h2=4.4.0=pyhcf101f3_0
+  - hpack=4.2.0=pyhd8ed1ab_0
   - hyperframe=6.1.0=pyhd8ed1ab_0
-  - idna=3.10=pyhd8ed1ab_1
-  - ipopt=3.14.17=h59d4785_0
-  - ld_impl_linux-64=2.43=h712a8e2_2
-  - libblas=3.9.0=29_h59b9bed_openblas
-  - libcblas=3.9.0=29_he106b2a_openblas
-  - libexpat=2.6.4=h5888daf_0
-  - libffi=3.4.6=h2dba641_0
-  - libgcc=14.2.0=h77fa898_1
-  - libgcc-ng=14.2.0=h69a702a_1
-  - libgfortran=14.2.0=h69a702a_1
-  - libgfortran-ng=14.2.0=h69a702a_1
-  - libgfortran5=14.2.0=hd5240d6_1
-  - libhwloc=2.11.2=default_h0d58e46_1001
-  - libiconv=1.17=hd590300_2
-  - liblapack=3.9.0=29_h7ac8fdf_openblas
-  - liblapacke=3.9.0=29_he2f377e_openblas
-  - liblzma=5.6.4=hb9d3cd8_0
-  - liblzma-devel=5.6.4=hb9d3cd8_0
-  - libnsl=2.0.1=hd590300_0
-  - libopenblas=0.3.28=pthreads_h94d23a6_1
+  - icu=75.1=he02047a_0
+  - idna=3.18=pyhcf101f3_0
+  - ipopt=3.14.17=h7fd866c_2
+  - ld_impl_linux-64=2.46.1=default_hbd61a6d_102
+  - libblas=3.11.0=8_h4a7cf45_openblas
+  - libcblas=3.11.0=8_h0358290_openblas
+  - libexpat=2.8.1=hecca717_1
+  - libffi=3.5.2=h3435931_0
+  - libgcc=16.1.0=ha9f2e26_1
+  - libgcc-ng=16.1.0=h69a702a_1
+  - libgfortran=16.1.0=h69a702a_1
+  - libgfortran-ng=16.1.0=h69a702a_1
+  - libgfortran5=16.1.0=h79bb938_1
+  - libgomp=16.1.0=he0feb66_1
+  - libhwloc=2.11.2=default_h3d81e11_1002
+  - libiconv=1.18=h3b78370_2
+  - liblapack=3.11.0=8_h47877c9_openblas
+  - liblapacke=3.11.0=8_h6ae95b6_openblas
+  - liblzma=5.8.3=hb03c661_0
+  - liblzma-devel=5.8.3=hb03c661_0
+  - libnsl=2.0.1=hb9d3cd8_1
+  - libopenblas=0.3.33=pthreads_h94d23a6_0
   - libscotch=7.0.4=h2fe6a88_5
-  - libspral=2024.05.08=h2b245be_4
-  - libsqlite=3.48.0=hee588c1_1
-  - libstdcxx=14.2.0=hc0a3c3a_1
-  - libstdcxx-ng=14.2.0=h4852527_1
-  - libuuid=2.38.1=h0b41bf4_0
+  - libspral=2025.03.06=h39c1cf3_0
+  - libsqlite=3.53.4=h0c1763c_0
+  - libstdcxx=16.1.0=h934c35e_1
+  - libstdcxx-ng=16.1.0=hdf11a46_1
+  - libuuid=2.42.2=h5347b49_0
   - libxcrypt=4.4.36=hd590300_1
-  - libxml2=2.13.5=h0d44e9d_1
-  - libzlib=1.3.1=hb9d3cd8_2
-  - llvm-openmp=19.1.7=h024ca30_0
+  - libxml2=2.13.9=h04c0eec_0
+  - libzlib=1.3.2=h25fd6f3_3
   - metis=5.1.0=hd0bcaf9_1007
-  - mkl=2024.2.2=ha957f24_16
-  - mpfr=4.2.1=h90cbb55_3
-  - mumps-include=5.7.3=ha770c72_7
+  - mpfr=4.2.2=he0a73b1_0
+  - mumps-include=5.7.3=h82cca05_10
   - mumps-seq=5.7.3=h27a6a8b_0
-  - ncurses=6.5=h2d0b736_3
-  - openssl=3.4.1=h7b32b05_0
-  - pip=25.0.1=pyh8b19718_0
-  - pycparser=2.22=pyh29332c3_1
+  - ncurses=6.6=hdb14827_0
+  - openssl=3.6.3=h35e630c_0
+  - packaging=26.2=pyhc364b38_0
+  - pip=26.2=pyh8b19718_0
+  - psutil=7.2.2=py312h5253ce2_0
   - pyscipopt=5.3.0=py312h2ec8cdc_0
   - pysocks=1.7.1=pyha55dd90_7
-  - python=3.12.9=h9e4cc4f_0_cpython
-  - python_abi=3.12=5_cp312
-  - readline=8.2=h8228510_1
-  - requests=2.32.3=pyhd8ed1ab_1
+  - python=3.12.13=hd63d673_0_cpython
+  - python_abi=3.12=8_cp312
+  - readline=8.3=h853b02a_0
+  - requests=2.34.2=pyhcf101f3_0
   - scip=9.2.1=h072bc7a_0
-  - setuptools=75.8.0=pyhff2d567_0
-  - tbb=2021.13.0=hceb3a55_1
-  - tk=8.6.13=noxft_h4845f30_101
-  - urllib3=2.3.0=pyhd8ed1ab_0
-  - wheel=0.45.1=pyhd8ed1ab_1
-  - xz=5.6.4=hbcc6ac9_0
-  - xz-gpl-tools=5.6.4=hbcc6ac9_0
-  - xz-tools=5.6.4=hb9d3cd8_0
-  - zlib=1.3.1=hb9d3cd8_2
-  - zstandard=0.23.0=py312hef9b889_1
-  - zstd=1.5.6=ha6fb4c9_0
+  - setuptools=83.0.0=pyh332efcf_0
+  - tbb=2022.1.0=h4ce085d_0
+  - tk=8.6.13=noxft_hd70dff1_3
+  - tzdata=2026c=h151e31d_0
+  - urllib3=2.7.0=pyhd8ed1ab_0
+  - wheel=0.47.0=pyhd8ed1ab_0
+  - xz=5.8.3=ha02ee65_0
+  - xz-gpl-tools=5.8.3=ha02ee65_0
+  - xz-tools=5.8.3=hb03c661_0
+  - zlib=1.3.2=h25fd6f3_3
+  - zstd=1.5.7=hb78ec9c_6
   - pip:
-      - bottleneck==1.4.2
-      - click==8.1.8
-      - cloudpickle==3.1.1
-      - dask==2025.2.0
+      - bottleneck==1.6.0
+      - click==8.4.2
+      - cloudpickle==3.1.2
+      - dask==2026.7.1
       - deprecation==2.1.0
-      - fsspec==2025.2.0
+      - fsspec==2026.7.0
       - highspy==1.9.0
-      - linopy==0.5.0
+      - linopy==0.9.0
       - locket==1.0.0
-      - numexpr==2.10.2
-      - numpy==1.26.4
-      - packaging==24.2
-      - pandas==2.2.3
+      - numexpr==2.14.2
+      - numpy==2.5.1
+      - pandas==3.0.5
       - partd==1.4.2
-      - polars==1.22.0
+      - polars==1.43.2
+      - polars-runtime-32==1.43.2
       - python-dateutil==2.9.0.post0
-      - pytz==2025.1
-      - pyyaml==6.0.2
-      - scipy==1.15.1
+      - pyyaml==6.0.3
+      - scipy==1.18.0
       - six==1.17.0
-      - toolz==1.0.0
-      - tqdm==4.67.1
-      - tzdata==2025.1
-      - xarray==2025.1.2
-      - psutil==5.9.8
+      - toolz==1.1.0
+      - tqdm==4.70.0
+      - xarray==2026.7.0

--- a/runner/envs/benchmark-tests.yaml
+++ b/runner/envs/benchmark-tests.yaml
@@ -4,7 +4,7 @@ channels:
 - https://conda.anaconda.org/gurobi
 - nodefaults
 dependencies:
-- python>=3.12
+- python>=3.12,<3.13
 - pip
 - psutil>=5.9
 
@@ -17,4 +17,4 @@ dependencies:
 
 - pip:
   - highspy==1.9.0
-  - linopy>=0.5.0
+  - linopy==0.9.0

--- a/runner/run_solver.py
+++ b/runner/run_solver.py
@@ -82,7 +82,7 @@ def get_solver(solver_name):
         "xpress": {"miprelgapnotify": mip_gap, "randomseed": 0},
     }
 
-    return solver_class(**seed_options.get(solver_name, {}))
+    return solver_class(options=seed_options.get(solver_name, {}))
 
 
 def is_mip_problem(solver_model, solver_name):


### PR DESCRIPTION
This PR updates linopy to version 0.9.0 in the test and 2025 benchmark environments, and also restricts Python to 3.12 release, updating the corresponding fixed environment files and adapting solver initialization to the linopy 0.9.0 API by passing solver options through the `options` argument.

I verified locally that:
- no `unexpected keyword argument` errors remain
- the fixed environments use Python 3.12.13 and Linopy 0.9.0
- the original conda channels are preserved