### PR TITLE
Correct metadata for pypsa-eur-sec-50-168h

### DIFF
--- a/benchmarks/pypsa/metadata.yaml
+++ b/benchmarks/pypsa/metadata.yaml
@@ -447,7 +447,7 @@ problems:
     Modelling framework: PyPSA
     Version:
     Spatial resolution: 50 nodes
-    Temporal resolution: 24 hours
+    Temporal resolution: 168 hours
     Realistic: false
     Application: Infrastructure & Capacity Expansion
     Sectoral focus: Sector-coupled

--- a/results/metadata.yaml
+++ b/results/metadata.yaml
@@ -3726,7 +3726,7 @@ problems:
     Modelling framework: PyPSA
     Version:
     Spatial resolution: 50 nodes
-    Temporal resolution: 24 hours
+    Temporal resolution: 168 hours
     Realistic: false
     Application: Infrastructure & Capacity Expansion
     Sectoral focus: Sector-coupled


### PR DESCRIPTION
Fixes #566 

### Benchmark contributions

Fix metadata for pypsa-eur-sec-50-168h.